### PR TITLE
feat(@molt/command): allow passing arguments from the environment

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
   ],
   "overrides": [],
   "rules": {
+    "@typescript-eslint/consistent-type-imports": "warn",
     // Enforce backticks
     // Note you must disable the base rule as it can report incorrect errors.
     "quotes": "off",

--- a/packages/@molt/command/README.md
+++ b/packages/@molt/command/README.md
@@ -58,7 +58,7 @@ npm add @molt/command
 
 Parameter arguments can be passed by environment variables instead of traditional flags.
 
-Flags take precedence over environment variables because flags generally come later than environment variables (e.g. shell has some exported environment variables).
+Environment arguments have lower precedence than Flags, so if an argument is available from both the flag and the environment, only the flag argument is used.
 
 Environment variables follow this pattern by default:
 

--- a/packages/@molt/command/package.json
+++ b/packages/@molt/command/package.json
@@ -34,6 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@molt/types": "workspace:*",
+    "alge": "0.7.0-next.1",
     "lodash.camelcase": "^4.3.0",
     "ts-toolbelt": "^9.6.0",
     "zod": "^3.19.1"

--- a/packages/@molt/command/src/Errors/Errors.ts
+++ b/packages/@molt/command/src/Errors/Errors.ts
@@ -1,4 +1,4 @@
-import type { FlagSpec } from '../index_.js'
+import type { FlagSpec } from '../flagSpec.js'
 import type { z } from 'zod'
 
 export class ErrorMissingFlagArgument extends Error {

--- a/packages/@molt/command/src/Errors/Errors.ts
+++ b/packages/@molt/command/src/Errors/Errors.ts
@@ -1,0 +1,33 @@
+import type { FlagSpec } from '../index_.js'
+import type { z } from 'zod'
+
+export class ErrorMissingFlagArgument extends Error {
+  constructor(params: { flagName: string }) {
+    const message = `Missing argument for flag "${params.flagName}".`
+    super(message)
+  }
+}
+
+export class ErrorMissingArgument extends Error {
+  constructor(params: { flagSpec: FlagSpec }) {
+    const message = `Missing argument for flag "${params.flagSpec.canonical}".`
+    super(message)
+  }
+}
+
+export class ErrorInvalidArgument extends Error {
+  constructor(params: {
+    environmentVariableName?: string
+    parameterName: string
+    validationError: z.ZodError
+  }) {
+    const message = `Invalid argument${
+      params.environmentVariableName
+        ? ` (via environment variable "${params.environmentVariableName}") `
+        : ` `
+    }for parameter: "${params.parameterName}". The error was:\n${params.validationError
+      .format()
+      ._errors.join(`\n`)}`
+    super(message)
+  }
+}

--- a/packages/@molt/command/src/Errors/index.ts
+++ b/packages/@molt/command/src/Errors/index.ts
@@ -1,0 +1,1 @@
+export * as Errors from './Errors.js'

--- a/packages/@molt/command/src/environment.ts
+++ b/packages/@molt/command/src/environment.ts
@@ -1,0 +1,28 @@
+export const defaultParameterNamePrefixes = [`CLI_PARAMETER`, `CLI_PARAM`] as const
+
+export const environmentArgumentName = (name: string) => `${defaultParameterNamePrefixes[0]}_${name}`
+
+export const getProcessEnvironmentLowerCase = () =>
+  Object.fromEntries(Object.entries(process.env).map(([k, v]) => [k.toLowerCase(), v?.trim()]))
+
+export const lookupEnvironmentVariableArgument = (
+  prefixes: readonly string[],
+  environment: Record<string, string | undefined>,
+  parameterName: string
+): null | { name: string; value: string } => {
+  const args = prefixes
+    .map((prefix) => `${prefix.toLowerCase()}_${parameterName.toLowerCase()}`)
+    .map((name) => ({ name, value: environment[name] }))
+    .filter((arg): arg is { name: string; value: string } => arg.value !== undefined)
+
+  if (args.length === 0) return null
+
+  if (args.length > 1)
+    throw new Error(
+      `Multiple environment variables found for same parameter "${parameterName}": ${args.join(`, `)}`
+    )
+
+  // eslint-disable-next-line
+  const environmentVariable = args[0]!
+  return environmentVariable
+}

--- a/packages/@molt/command/src/environment.ts
+++ b/packages/@molt/command/src/environment.ts
@@ -1,6 +1,6 @@
 export const defaultParameterNamePrefixes = [`CLI_PARAMETER`, `CLI_PARAM`]
 
-export const environmentArgumentName = (name: string) => `${defaultParameterNamePrefixes[0]}_${name}`
+export const environmentArgumentName = (name: string) => `${String(defaultParameterNamePrefixes[0])}_${name}`
 
 export const getProcessEnvironmentLowerCase = () =>
   Object.fromEntries(Object.entries(process.env).map(([k, v]) => [k.toLowerCase(), v?.trim()]))

--- a/packages/@molt/command/src/environment.ts
+++ b/packages/@molt/command/src/environment.ts
@@ -1,4 +1,4 @@
-export const defaultParameterNamePrefixes = [`CLI_PARAMETER`, `CLI_PARAM`] as const
+export const defaultParameterNamePrefixes = [`CLI_PARAMETER`, `CLI_PARAM`]
 
 export const environmentArgumentName = (name: string) => `${defaultParameterNamePrefixes[0]}_${name}`
 
@@ -6,12 +6,16 @@ export const getProcessEnvironmentLowerCase = () =>
   Object.fromEntries(Object.entries(process.env).map(([k, v]) => [k.toLowerCase(), v?.trim()]))
 
 export const lookupEnvironmentVariableArgument = (
-  prefixes: readonly string[],
+  prefixes: string[],
   environment: Record<string, string | undefined>,
   parameterName: string
 ): null | { name: string; value: string } => {
-  const args = prefixes
-    .map((prefix) => `${prefix.toLowerCase()}_${parameterName.toLowerCase()}`)
+  const parameterNames =
+    prefixes.length === 0
+      ? [parameterName]
+      : prefixes.map((prefix) => `${prefix.toLowerCase()}_${parameterName.toLowerCase()}`)
+
+  const args = parameterNames
     .map((name) => ({ name, value: environment[name] }))
     .filter((arg): arg is { name: string; value: string } => arg.value !== undefined)
 

--- a/packages/@molt/command/src/flagSpec.ts
+++ b/packages/@molt/command/src/flagSpec.ts
@@ -1,0 +1,108 @@
+import type { SchemaBase } from './types.js'
+import camelCase from 'lodash.camelcase'
+import type { z } from 'zod'
+import { stripeDashPrefix } from './helpers.js'
+
+export type FlagSpec =
+  | {
+      _tag: 'Long'
+      canonical: string
+      schema: z.ZodType
+      schemaBase: SchemaBase
+      long: string
+      short: undefined
+      aliases: {
+        short: [...string[]]
+        long: [...string[]]
+      }
+    }
+  | {
+      _tag: 'Short'
+      schema: z.ZodType
+      schemaBase: SchemaBase
+      canonical: string
+      long: undefined
+      short: string
+      aliases: {
+        short: [...string[]]
+        long: [...string[]]
+      }
+    }
+  | {
+      _tag: 'LongShort'
+      schema: z.ZodType
+      schemaBase: SchemaBase
+      canonical: string
+      long: string
+      short: string
+      aliases: {
+        short: [...string[]]
+        long: [...string[]]
+      }
+    }
+
+export const parseFlagSpecs = (schema: z.ZodRawShape): FlagSpec[] =>
+  Object.entries(schema).map(([expression, schema]) => {
+    const names = expression
+      .trim()
+      .split(` `)
+      .map((exp) => exp.trim())
+      .map(stripeDashPrefix)
+
+    // eslint-disable-next-line
+    const spec: FlagSpec = {
+      long: undefined,
+      short: undefined,
+      schema,
+      aliases: {
+        long: [],
+        short: [],
+      },
+      // eslint-disable-next-line
+    } as any
+
+    for (const name of names) {
+      if (name.length === 1)
+        if (spec.short) spec.aliases.short.push(name)
+        else spec.short = name
+      else if (name.length > 1)
+        if (spec.long) spec.aliases.long.push(camelCase(name))
+        else spec.long = camelCase(name)
+      else throw new Error(`Invalid flag name: ${name}`)
+    }
+
+    if (spec.short && spec.long) {
+      spec._tag = `LongShort`
+      spec.canonical = camelCase(spec.long)
+    } else if (spec.short) {
+      spec._tag = `Short`
+      spec.canonical = spec.short
+    } else if (spec.long) {
+      spec._tag = `Long`
+      spec.canonical = camelCase(spec.long)
+    } else throw new Error(`Invalid flag name: ${names.join(` `)}`)
+
+    spec.schemaBase = getSchemaBase(spec.schema)
+
+    return spec
+  })
+
+const getSchemaBase = (schema: z.ZodSchema): SchemaBase => {
+  // @ts-expect-error ignore-me
+  if (schema._def.typeName === `ZodDefault`) {
+    // @ts-expect-error ignore-me
+    // eslint-disable-next-line
+    return getSchemaBase(schema._def.innerType)
+  }
+
+  // @ts-expect-error ignore-me
+  if (schema._def.typeName === `ZodOptional`) {
+    // @ts-expect-error ignore-me
+    // eslint-disable-next-line
+    return getSchemaBase(schema._def.innerType)
+  }
+
+  // @ts-expect-error ignore-me
+  // eslint-disable-next-line
+  return schema._def.typeName
+}

--- a/packages/@molt/command/src/flagSpec.ts
+++ b/packages/@molt/command/src/flagSpec.ts
@@ -1,7 +1,7 @@
+import { stripeDashPrefix } from './helpers.js'
 import type { SchemaBase } from './types.js'
 import camelCase from 'lodash.camelcase'
 import type { z } from 'zod'
-import { stripeDashPrefix } from './helpers.js'
 
 export type FlagSpec =
   | {

--- a/packages/@molt/command/src/helpers.ts
+++ b/packages/@molt/command/src/helpers.ts
@@ -1,32 +1,7 @@
 import { Alge } from 'alge'
 
-export const getProcessEnvironmentLowerCase = () =>
-  Object.fromEntries(Object.entries(process.env).map(([k, v]) => [k.toLowerCase(), v?.trim()]))
-
 export const stripeDashPrefix = (flagNameInput: string): string => {
   return flagNameInput.replace(/^-+/, ``)
-}
-
-export const lookupEnvironmentVariableArgument = (
-  prefixes: readonly string[],
-  environment: Record<string, string | undefined>,
-  parameterName: string
-): null | { name: string; value: string } => {
-  const args = prefixes
-    .map((prefix) => `${prefix.toLowerCase()}_${parameterName.toLowerCase()}`)
-    .map((name) => ({ name, value: environment[name] }))
-    .filter((arg): arg is { name: string; value: string } => arg.value !== undefined)
-
-  if (args.length === 0) return null
-
-  if (args.length > 1)
-    throw new Error(
-      `Multiple environment variables found for same parameter "${parameterName}": ${args.join(`, `)}`
-    )
-
-  // eslint-disable-next-line
-  const environmentVariable = args[0]!
-  return environmentVariable
 }
 
 export const parsePrimitive = (

--- a/packages/@molt/command/src/helpers.ts
+++ b/packages/@molt/command/src/helpers.ts
@@ -1,0 +1,42 @@
+import { Alge } from 'alge'
+
+export const getProcessEnvironmentLowerCase = () =>
+  Object.fromEntries(Object.entries(process.env).map(([k, v]) => [k.toLowerCase(), v?.trim()]))
+
+export const stripeDashPrefix = (flagNameInput: string): string => {
+  return flagNameInput.replace(/^-+/, ``)
+}
+
+export const lookupEnvironmentVariableArgument = (
+  prefixes: readonly string[],
+  environment: Record<string, string | undefined>,
+  parameterName: string
+): null | { name: string; value: string } => {
+  const args = prefixes
+    .map((prefix) => `${prefix.toLowerCase()}_${parameterName.toLowerCase()}`)
+    .map((name) => ({ name, value: environment[name] }))
+    .filter((arg): arg is { name: string; value: string } => arg.value !== undefined)
+
+  if (args.length === 0) return null
+
+  if (args.length > 1)
+    throw new Error(
+      `Multiple environment variables found for same parameter "${parameterName}": ${args.join(`, `)}`
+    )
+
+  // eslint-disable-next-line
+  const environmentVariable = args[0]!
+  return environmentVariable
+}
+
+export const parsePrimitive = (
+  value: string,
+  parseTo: 'number' | 'string' | 'boolean'
+): null | number | string | boolean =>
+  Alge.match(parseTo)
+    .boolean(() => parseEnvironmentVariableBoolean(value))
+    .number(() => Number(value))
+    .else(() => value)
+
+export const parseEnvironmentVariableBoolean = (value: string) =>
+  value === `true` ? true : value === `false` ? false : null

--- a/packages/@molt/command/src/index_.ts
+++ b/packages/@molt/command/src/index_.ts
@@ -222,12 +222,16 @@ const parseProcessArguments = (
       .filter(([_name, environmentVariables]) => {
         return Boolean(environmentVariables.find((envar) => envar[2]))
       })
-      .map((entry) => [entry[0], entry[1].map((envar) => [envar[0], envar[1]])])
+      .map((entry): [string, [string, string | undefined][]] => [
+        entry[0],
+        entry[1].map((envar) => [envar[0], envar[1]]),
+      ])
     if (argsPassedUnknown.length > 0) {
       throw new Error(
         `Environment variables appearing to be CLI parameter arguments were found but do not correspond to any actual parameters. This probably indicates a typo or some other kind of error: ${JSON.stringify(
-          // @ts-expect-error todo
-          Object.fromEntries(argsPassedUnknown.map((entry) => [entry[0], Object.fromEntries(entry[1])])),
+          Object.fromEntries(
+            argsPassedUnknown.sort().map((entry) => [entry[0], Object.fromEntries(entry[1].sort())])
+          ),
           null,
           2
         )}`
@@ -237,13 +241,17 @@ const parseProcessArguments = (
       .filter(([_name, environmentVariables]) => {
         return environmentVariables.length > 1
       })
-      .map((entry) => [entry[0], entry[1].map((envar) => [envar[0], envar[1]])])
+      .map((entry): [string, [string, string | undefined][]] => [
+        entry[0],
+        entry[1].map((envar) => [envar[0], envar[1]]),
+      ])
     if (argsPassedViaMultiple.length > 0) {
       const params = argsPassedViaMultiple.map((args) => `"${String(args[0])}"`).join(`, `)
       throw new Error(
         `Parameter(s) ${params} received arguments multiple times via different environment variables: ${JSON.stringify(
-          // @ts-expect-error todo
-          Object.fromEntries(argsPassedViaMultiple.map((entry) => [entry[0], Object.fromEntries(entry[1])])),
+          Object.fromEntries(
+            argsPassedViaMultiple.sort().map((entry) => [entry[0], Object.fromEntries(entry[1].sort())])
+          ),
           null,
           2
         )}`

--- a/packages/@molt/command/src/index_.ts
+++ b/packages/@molt/command/src/index_.ts
@@ -71,7 +71,7 @@ type Definition<ParametersSchema extends z.ZodRawShape> = {
 
 export const create = <Schema extends z.ZodRawShape>(schema: Schema): Definition<Schema> => {
   const settingsDefaults: SettingsNormalized = {
-    environmentArguments: false,
+    environmentArguments: true,
   }
   const settings = { ...settingsDefaults }
 

--- a/packages/@molt/command/src/index_.ts
+++ b/packages/@molt/command/src/index_.ts
@@ -1,13 +1,12 @@
+import {
+  defaultParameterNamePrefixes,
+  getProcessEnvironmentLowerCase,
+  lookupEnvironmentVariableArgument,
+} from './environment.js'
 import { Errors } from './Errors/index.js'
 import type { FlagSpec } from './flagSpec.js'
 import { parseFlagSpecs } from './flagSpec.js'
-import {
-  getProcessEnvironmentLowerCase,
-  lookupEnvironmentVariableArgument,
-  parseEnvironmentVariableBoolean,
-  parsePrimitive,
-  stripeDashPrefix,
-} from './helpers.js'
+import { parseEnvironmentVariableBoolean, parsePrimitive } from './helpers.js'
 import type {
   ArgumentsInput,
   ArgumentsInputStructured,
@@ -19,10 +18,6 @@ import type { FlagName } from '@molt/types'
 import { Alge } from 'alge'
 import type { Any } from 'ts-toolbelt'
 import { z } from 'zod'
-
-const defaultParameterNamePrefixes = [`CLI_PARAMETER`, `CLI_PARAM`] as const
-
-export const environmentArgumentName = (name: string) => `${defaultParameterNamePrefixes[0]}_${name}`
 
 const toCanonicalParameterName = (parameterName: string) =>
   parameterName.replace(/^cli_(?:param|parameter)_/i, ``)

--- a/packages/@molt/command/src/index_.ts
+++ b/packages/@molt/command/src/index_.ts
@@ -107,7 +107,6 @@ export const create = <Schema extends z.ZodRawShape>(schema: Schema): Definition
     },
     parseOrThrow: (processArguments) => {
       // eslint-disable-next-line
-      // console.log({ settings })
       return parseProcessArguments(schema, processArguments ?? process.argv.slice(2), settings) as any
     },
     schema,
@@ -200,6 +199,7 @@ const parseProcessArguments = (
         )
       })
       .reduce((acc, [prefixedName, value]) => {
+        // eslint-disable-next-line
         const prefix = settings.environmentArguments.prefix.find((prefix) =>
           prefixedName.startsWith(prefix.toLowerCase())
         )!
@@ -213,6 +213,7 @@ const parseProcessArguments = (
               Boolean(spec.aliases.short.find((_) => _ === name))
           ) === undefined
         acc[name] = acc[name] ?? []
+        // eslint-disable-next-line
         acc[name]!.push([prefix, value, unknownName])
         return acc
       }, {} as Record<string, [string, string | undefined, boolean][]>)
@@ -238,7 +239,7 @@ const parseProcessArguments = (
       })
       .map((entry) => [entry[0], entry[1].map((envar) => [envar[0], envar[1]])])
     if (argsPassedViaMultiple.length > 0) {
-      const params = argsPassedViaMultiple.map((args) => `"${args[0]}"`).join(`, `)
+      const params = argsPassedViaMultiple.map((args) => `"${String(args[0])}"`).join(`, `)
       throw new Error(
         `Parameter(s) ${params} received arguments multiple times via different environment variables: ${JSON.stringify(
           // @ts-expect-error todo

--- a/packages/@molt/command/src/structureProcessArguments.ts
+++ b/packages/@molt/command/src/structureProcessArguments.ts
@@ -1,0 +1,65 @@
+import { stripeDashPrefix } from './helpers.js'
+import camelCase from 'lodash.camelcase'
+
+export type ArgumentsInput = string[]
+
+export type ArgumentsInputStructuredArgFlag = {
+  _tag: 'Arguments'
+  arguments: string[]
+}
+
+export type ArgumentsInputStructuredBooleanFlag = {
+  _tag: 'Boolean'
+  negated: boolean
+}
+
+export type ArgumentsInputStructured = Record<
+  string,
+  ArgumentsInputStructuredArgFlag | ArgumentsInputStructuredBooleanFlag
+>
+
+export const structureProcessArguments = (argumentsInput: ArgumentsInput): ArgumentsInputStructured => {
+  // console.log({ argumentsInput })
+  const structured: ArgumentsInputStructured = {}
+  let index = 0
+  let currentFlag: null | ArgumentsInputStructuredArgFlag | ArgumentsInputStructuredBooleanFlag = null
+
+  for (const argument of argumentsInput) {
+    const trimmed = argument.trim()
+
+    if (isFlagInput(trimmed)) {
+      const noDashPrefix = stripeDashPrefix(trimmed)
+      if (
+        !argumentsInput[index + 1] ||
+        //eslint-disable-next-line
+        (argumentsInput[index + 1] && isFlagInput(argumentsInput[index + 1]!))
+      ) {
+        currentFlag = {
+          _tag: `Boolean`,
+          // TODO handle camel case negation like --noWay
+          negated: noDashPrefix.startsWith(`no-`),
+        }
+        const noNegatePrefix = noDashPrefix.replace(`no-`, ``)
+        const camelized = camelCase(noNegatePrefix)
+        structured[camelized] = currentFlag
+      } else {
+        currentFlag = {
+          _tag: `Arguments`,
+          arguments: [],
+        }
+        structured[camelCase(noDashPrefix)] = currentFlag
+      }
+    } else if (currentFlag && currentFlag._tag === `Arguments`) {
+      currentFlag.arguments.push(trimmed)
+    }
+
+    index++
+  }
+
+  // console.log({ structured })
+  return structured
+}
+
+const isFlagInput = (input: string) => {
+  return input.trim().startsWith(`--`) || input.trim().startsWith(`-`)
+}

--- a/packages/@molt/command/src/types.ts
+++ b/packages/@molt/command/src/types.ts
@@ -1,0 +1,1 @@
+export type SchemaBase = 'ZodBoolean' | 'ZodNumber' | 'ZodString'

--- a/packages/@molt/command/tests/environment.spec.ts
+++ b/packages/@molt/command/tests/environment.spec.ts
@@ -24,9 +24,10 @@ const environmentManager = createEnvironmentManager()
 beforeEach(environmentManager.reset)
 
 describe(`toggling`, () => {
-  it(`is disabled by default`, () => {
-    environmentManager.set(`cli_foo`, `bar`)
-    expect(() => Command.create({ '--foo': z.string() }).parseOrThrow([])).toThrow()
+  it(`is enabled by default`, () => {
+    environmentManager.set(`cli_parameter_foo`, `bar`)
+    const args = Command.create({ '--foo': z.string() }).parseOrThrow([])
+    expect(args).toEqual({ foo: `bar` })
   })
   it(`can be enabled by settings`, () => {
     environmentManager.set(`cli_param_foo`, `bar`)
@@ -36,13 +37,19 @@ describe(`toggling`, () => {
     expect(args).toEqual({ foo: `bar` })
   })
   it(`can be enabled by environment`, () => {
-    environmentManager.set(`CLI_SETTINGS_READ_ARGUMENTS_FROM_ENVIRONMENT`, `true`)
+    environmentManager.set(`ClI_settings_READ_arguments_FROM_ENVIRONMENT`, `true`)
     environmentManager.set(`cli_param_foo`, `bar`)
     const args = Command.create({ '--foo': z.string() }).parseOrThrow([])
     expect(args).toEqual({ foo: `bar` })
   })
+  it(`can be disabled by environment`, () => {
+    environmentManager.set(`ClI_settings_READ_arguments_FROM_ENVIRONMENT`, `false`)
+    environmentManager.set(`cli_param_foo`, `bar`)
+    const args = Command.create({ '--foo': z.string().default(`x`) }).parseOrThrow([])
+    expect(args).toEqual({ foo: `x` })
+  })
   it(`environment supersedes settings`, () => {
-    environmentManager.set(`CLI_SETTINGS_READ_ARGUMENTS_FROM_ENVIRONMENT`, `false`)
+    environmentManager.set(`ClI_settings_READ_arguments_FROM_ENVIRONMENT`, `false`)
     environmentManager.set(`cli_foo`, `bar`)
     expect(() =>
       Command.create({ '--foo': z.string() })

--- a/packages/@molt/command/tests/environment.spec.ts
+++ b/packages/@molt/command/tests/environment.spec.ts
@@ -114,13 +114,13 @@ describe(`prefix`, () => {
       ).toThrowErrorMatchingInlineSnapshot(
         `
         "Parameter(s) \\"foo\\", \\"bar\\" received arguments multiple times via different environment variables: {
-          \\"foo\\": {
+          \\"bar\\": {
             \\"CLI_PARAM\\": \\"qux1\\",
             \\"CLI_PARAMETER\\": \\"qux2\\"
           },
-          \\"bar\\": {
-            \\"CLI_PARAMETER\\": \\"qux2\\",
-            \\"CLI_PARAM\\": \\"qux1\\"
+          \\"foo\\": {
+            \\"CLI_PARAM\\": \\"qux1\\",
+            \\"CLI_PARAMETER\\": \\"qux2\\"
           }
         }"
       `

--- a/packages/@molt/command/tests/environment.spec.ts
+++ b/packages/@molt/command/tests/environment.spec.ts
@@ -1,0 +1,106 @@
+import { Command } from '../src/index.js'
+import { beforeEach, expect } from 'vitest'
+import { describe, it } from 'vitest'
+import { z } from 'zod'
+
+const createEnvironmentManager = () => {
+  let changes: Record<string, string | undefined> = {}
+  return {
+    set: (key: string, value: string) => {
+      changes[key] = value
+      process.env[key] = value
+    },
+    reset: () => {
+      Object.keys(changes).forEach((key) => {
+        delete process.env[key]
+      })
+      changes = {}
+    },
+  }
+}
+
+const environmentManager = createEnvironmentManager()
+
+beforeEach(environmentManager.reset)
+
+describe(`toggling`, () => {
+  it(`is disabled by default`, () => {
+    environmentManager.set(`cli_foo`, `bar`)
+    expect(() => Command.create({ '--foo': z.string() }).parseOrThrow([])).toThrow()
+  })
+  it(`can be enabled by settings`, () => {
+    environmentManager.set(`cli_foo`, `bar`)
+    const args = Command.create({ '--foo': z.string() })
+      .settings({ readArgumentsFromEnvironment: true })
+      .parseOrThrow([])
+    expect(args).toEqual({ foo: `bar` })
+  })
+  it(`can be enabled by environment`, () => {
+    environmentManager.set(`cli_environment_args`, `true`)
+    environmentManager.set(`cli_foo`, `bar`)
+    const args = Command.create({ '--foo': z.string() }).parseOrThrow([])
+    expect(args).toEqual({ foo: `bar` })
+  })
+  it(`environment supersedes settings`, () => {
+    environmentManager.set(`cli_environment_args`, `false`)
+    environmentManager.set(`cli_foo`, `bar`)
+    expect(() =>
+      Command.create({ '--foo': z.string() })
+        .settings({ readArgumentsFromEnvironment: true })
+        .parseOrThrow([])
+    ).toThrow()
+  })
+})
+
+describe(`when enabled and a flag arg is not passed then the env is considered`, () => {
+  beforeEach(() => environmentManager.set(`CLI_ENV_ARGS`, `true`))
+
+  describe(`boolean`, () => {
+    it(`true`, () => {
+      environmentManager.set(`cli_VERBOSE`, `true`)
+      const args = Command.create({ '--verbose': z.boolean() }).parseOrThrow([])
+      expect(args).toEqual({ verbose: true })
+    })
+    it(`true (with param default false)`, () => {
+      environmentManager.set(`cli_VERBOSE`, `true`)
+      const args = Command.create({ '--verbose': z.boolean().default(false) }).parseOrThrow([])
+      expect(args).toEqual({ verbose: true })
+    })
+    it(`false`, () => {
+      environmentManager.set(`cli_verbose`, `false`)
+      const args = Command.create({ '--verbose': z.boolean() }).parseOrThrow([])
+      expect(args).toEqual({ verbose: false })
+    })
+  })
+
+  it(`string`, () => {
+    environmentManager.set(`cli_foo`, `bar`)
+    const args = Command.create({ '--foo': z.string() }).parseOrThrow([])
+    expect(args).toEqual({ foo: `bar` })
+  })
+  it(`number`, () => {
+    environmentManager.set(`cli_foo`, `4.3`)
+    const args = Command.create({ '--foo': z.number() }).parseOrThrow([])
+    expect(args).toEqual({ foo: 4.3 })
+  })
+  it(`env arg is validated`, () => {
+    environmentManager.set(`cLi_fOo`, `d`)
+    expect(() => Command.create({ '--foo': z.enum([`a`, `b`, `c`]) }).parseOrThrow([]))
+      .toThrowErrorMatchingInlineSnapshot(`
+        "Invalid argument (via environment variable \\"CLI_FOO\\") for parameter: \\"foo\\". The error was:
+        Invalid enum value. Expected 'a' | 'b' | 'c', received 'd'"
+      `)
+  })
+  it(`case of env name does not matter`, () => {
+    environmentManager.set(`cLi_fOo`, `bar`)
+    const args = Command.create({ '--foo': z.string() }).parseOrThrow([])
+    expect(args).toEqual({ foo: `bar` })
+  })
+})
+
+it(`if environment args enabled, parameter has default, flag arg not given, but env arg given, then env arg wins`, () => {
+  environmentManager.set(`CLI_ENV_ARGS`, `true`)
+  process.env[`cli_verbose`] = `true`
+  const args = Command.create({ '--verbose': z.boolean().default(false) }).parseOrThrow([])
+  expect(args).toEqual({ verbose: true })
+})

--- a/packages/@molt/command/tests/environment.spec.ts
+++ b/packages/@molt/command/tests/environment.spec.ts
@@ -1,3 +1,4 @@
+import { environmentArgumentName } from '../src/environment.js'
 import { Command } from '../src/index.js'
 import { beforeEach, expect } from 'vitest'
 import { describe, it } from 'vitest'
@@ -86,34 +87,34 @@ describe(`when enabled and a flag arg is not passed then the env is considered`,
 
   describe(`boolean`, () => {
     it(`true`, () => {
-      environmentManager.set(Command.environmentArgumentName(`VERBOSE`), `true`)
+      environmentManager.set(environmentArgumentName(`VERBOSE`), `true`)
       const args = Command.create({ '--verbose': z.boolean() }).parseOrThrow([])
       expect(args).toEqual({ verbose: true })
     })
     it(`true (with param default false)`, () => {
-      environmentManager.set(Command.environmentArgumentName(`VERBOSE`), `true`)
+      environmentManager.set(environmentArgumentName(`VERBOSE`), `true`)
       const args = Command.create({ '--verbose': z.boolean().default(false) }).parseOrThrow([])
       expect(args).toEqual({ verbose: true })
     })
     it(`false`, () => {
-      environmentManager.set(Command.environmentArgumentName(`verbose`), `false`)
+      environmentManager.set(environmentArgumentName(`verbose`), `false`)
       const args = Command.create({ '--verbose': z.boolean() }).parseOrThrow([])
       expect(args).toEqual({ verbose: false })
     })
   })
 
   it(`string`, () => {
-    environmentManager.set(Command.environmentArgumentName(`foo`), `bar`)
+    environmentManager.set(environmentArgumentName(`foo`), `bar`)
     const args = Command.create({ '--foo': z.string() }).parseOrThrow([])
     expect(args).toEqual({ foo: `bar` })
   })
   it(`number`, () => {
-    environmentManager.set(Command.environmentArgumentName(`foo`), `4.3`)
+    environmentManager.set(environmentArgumentName(`foo`), `4.3`)
     const args = Command.create({ '--foo': z.number() }).parseOrThrow([])
     expect(args).toEqual({ foo: 4.3 })
   })
   it(`env arg is validated`, () => {
-    environmentManager.set(Command.environmentArgumentName(`foo`), `d`)
+    environmentManager.set(environmentArgumentName(`foo`), `d`)
     expect(() => Command.create({ '--foo': z.enum([`a`, `b`, `c`]) }).parseOrThrow([]))
       .toThrowErrorMatchingInlineSnapshot(`
         "Invalid argument (via environment variable \\"CLI_PARAMETER_FOO\\") for parameter: \\"foo\\". The error was:

--- a/packages/@molt/command/tests/index.spec.ts
+++ b/packages/@molt/command/tests/index.spec.ts
@@ -1,5 +1,6 @@
 import { Command } from '../src/index.js'
-import { assert, IsExact } from 'conditional-type-checks'
+import type { IsExact } from 'conditional-type-checks'
+import { assert } from 'conditional-type-checks'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
@@ -109,7 +110,7 @@ describe(`#`, () => {
           expect(() =>
             Command.create({ '--name': z.string().regex(/[a-z]+/) }).parseOrThrow([`--name`, `BAD`])
           ).toThrowErrorMatchingInlineSnapshot(`
-            "Invalid argument for flag: \\"name\\". The error was:
+            "Invalid argument for parameter: \\"name\\". The error was:
             Invalid"
           `)
         })
@@ -137,7 +138,7 @@ describe(`#`, () => {
         it(`is validated`, () => {
           expect(() => Command.create({ '--age': z.number().int() }).parseOrThrow([`--age`, `1.1`]))
             .toThrowErrorMatchingInlineSnapshot(`
-              "Invalid argument for flag: \\"age\\". The error was:
+              "Invalid argument for parameter: \\"age\\". The error was:
               Expected integer, received float"
             `)
         })
@@ -160,9 +161,9 @@ describe(`#`, () => {
           // expect(args).toEqual({ mode: true })
           expect(() => Command.create({ '--mode': z.enum([`a`, `b`, `c`]) }).parseOrThrow([`--mode`, `bad`]))
             .toThrowErrorMatchingInlineSnapshot(`
-            "Invalid argument for flag: \\"mode\\". The error was:
-            Invalid enum value. Expected 'a' | 'b' | 'c', received 'bad'"
-          `)
+              "Invalid argument for parameter: \\"mode\\". The error was:
+              Invalid enum value. Expected 'a' | 'b' | 'c', received 'bad'"
+            `)
         })
       })
       describe(`boolean`, () => {

--- a/packages/@molt/types/src/FlagName/parser.ts
+++ b/packages/@molt/types/src/FlagName/parser.ts
@@ -1,6 +1,6 @@
-import { Str } from '../prelude.js'
-import { FlagNames, FlagNamesEmpty } from './data.js'
-import { String } from 'ts-toolbelt'
+import type { Str } from '../prelude.js'
+import type { FlagNames, FlagNamesEmpty } from './data.js'
+import type { String } from 'ts-toolbelt'
 
 // prettier-ignore
 export namespace Checks {

--- a/packages/@molt/types/tests/index.spec.ts
+++ b/packages/@molt/types/tests/index.spec.ts
@@ -1,4 +1,4 @@
-import { FlagName } from '../src/index.js'
+import type { FlagName } from '../src/index.js'
 import { expectType } from 'tsd'
 
 // eslint-disable-next-line
@@ -125,7 +125,6 @@ expectType<SomeLongShort>(as<FlagName.Parse<'  -v  --version  '>>())
 expectType<SomeLongShort>(as<FlagName.Parse<'  -v   --version '>>())
 expectType<SomeLongShort>(as<FlagName.Parse<'  v   version '>>())
 expectType<SomeLongShort>(as<FlagName.Parse<'v version'>>())
-type x = FlagName.Parse<'  v   version '>
 
 interface SomeLongCamelCase {
   long: 'fooBar'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,7 @@ importers:
     specifiers:
       '@molt/types': workspace:*
       '@types/lodash.camelcase': 4.3.7
+      alge: 0.7.0-next.1
       conditional-type-checks: 1.0.6
       execa: 6.1.0
       fast-glob: 3.2.12
@@ -75,6 +76,7 @@ importers:
       zod: ^3.19.1
     dependencies:
       '@molt/types': link:../types
+      alge: 0.7.0-next.1
       lodash.camelcase: 4.3.0
       ts-toolbelt: 9.6.0
       zod: 3.19.1
@@ -796,6 +798,15 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
     dev: true
+
+  /alge/0.7.0-next.1:
+    resolution: {integrity: sha512-QGB+1x1LJtVi9VKvzEU4oXXHcOXNmMRvX15Vks12AVltlBmxY0yrthn/+hh1tsU7mlPbXXPNw4aIklVoh628+w==}
+    dependencies:
+      lodash.ismatch: 4.4.0
+      remeda: 1.1.0
+      ts-toolbelt: 9.6.0
+      zod: 3.19.1
+    dev: false
 
   /ansi-escapes/4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -1817,6 +1828,10 @@ packages:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
     dev: false
 
+  /lodash.ismatch/4.4.0:
+    resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
+    dev: false
+
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
@@ -2164,6 +2179,10 @@ packages:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
     dev: true
+
+  /remeda/1.1.0:
+    resolution: {integrity: sha512-dtPAM1fP1HEorGDYyJiZUYfgzswyey0S1sD1FpCOhfgmpTJmnLz32q2WeEB1EyNLMENJuXSKWY8Hrm1CKM9lpw==}
+    dev: false
 
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -14,11 +14,12 @@ const args = Command.create({
   'b bump': z.enum([`major`, `minor`, `patch`]).optional(),
   publish: z.boolean().default(true),
   githubRelease: z.boolean().default(true),
+  githubToken: z.string(),
 }).parseOrThrow()
 
-const githubToken = process.env[`GITHUB_TOKEN`]
+// const githubToken = process.env[`GITHUB_TOKEN`]
 
-if (!githubToken) throw new Error(`GITHUB_TOKEN is required`)
+// if (!githubToken) throw new Error(`GITHUB_TOKEN is required`)
 
 if (!args.bump && !args.version) throw new Error(`--bump or --version is required`)
 if (args.bump && args.version) throw new Error(`--bump and --version cannot both be specified`)
@@ -66,7 +67,7 @@ if (args.publish) {
 
 if (args.githubRelease) {
   const octokit = new Octokit({
-    auth: githubToken,
+    auth: args.githubToken,
   })
 
   await octokit.request(`POST /repos/{owner}/{repo}/releases`, {


### PR DESCRIPTION
closes #...

#### TASKS

- [x] allow prefix disabling
- [x] allow prefix customization (single or list)
- [x] when prefix defined, typos are raised as errors