### PR TITLE
fix(@molt/command): paramter level prompt config object

### DIFF
--- a/packages/@molt/command/src/Builder/root/types.ts
+++ b/packages/@molt/command/src/Builder/root/types.ts
@@ -12,9 +12,9 @@ import { State } from '../State.js'
 
 export type Schema = ParameterSpec.SomeBasicType | ParameterSpec.SomeUnionType
 
-export interface ParameterConfiguration {
-  schema: Schema
-  prompt?: boolean
+export interface ParameterConfiguration<S extends Schema = Schema> {
+  schema: S
+  prompt?: ParameterSpec.Input.Prompt<S>
 }
 
 // prettier-ignore

--- a/packages/@molt/command/tests/prompt/__snapshots__/settings.spec.ts.snap
+++ b/packages/@molt/command/tests/prompt/__snapshots__/settings.spec.ts.snap
@@ -50,6 +50,31 @@ exports[`parameter defaults to custom settings > tty strip ansi 1`] = `
 ]
 `;
 
+exports[`parameter level > can be passed object > args 1`] = `
+{
+  "a": "foo",
+  "help": false,
+}
+`;
+
+exports[`parameter level > can be passed object > tty 1`] = `
+[
+  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "foo",
+  "
+",
+]
+`;
+
+exports[`parameter level > can be passed object > tty strip ansi 1`] = `
+[
+  "1/1  a",
+  "foo",
+  "
+",
+]
+`;
+
 exports[`parameter settings overrides default settings > args 1`] = `[ErrorMissingArgument: Missing argument for flag "a".]`;
 
 exports[`parameter settings overrides default settings > tty 1`] = `[]`;

--- a/packages/@molt/command/tests/prompt/settings.spec.ts
+++ b/packages/@molt/command/tests/prompt/settings.spec.ts
@@ -7,6 +7,20 @@ import { describe, expect, it } from 'vitest'
 
 const S = (settings: Settings.InputPrompt) => settings
 
+describe(`parameter level`, () => {
+  it(`can be passed object`, () => {
+    tty.mock.input.add([`foo`])
+    const args = tryCatch(() =>
+      Command.parameters({ a: { schema: s, prompt: { enabled: true } } })
+        .settings({ onError: `throw`, helpOnError: false })
+        .parse({ line: [], tty: tty.interface }),
+    )
+    expect(args).toMatchSnapshot(`args`)
+    expect(tty.history.all).toMatchSnapshot(`tty`)
+    expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+  })
+})
+
 it(`prompt is disabled by default`, () => {
   const args = tryCatch(() =>
     Command.parameters({ a: { schema: s } })


### PR DESCRIPTION
closes #...

#### TASKS

- [ ] Out of band docs (website, README, ...)
- [ ] In of band docs (jsdoc)
- [ ] Tests
