### PR TITLE
fix(@molt/command): type-safe settings prompt omitted

### DIFF
--- a/packages/@molt/command/examples/intro.ts
+++ b/packages/@molt/command/examples/intro.ts
@@ -1,31 +1,29 @@
 import { Command } from '../src/index.js'
 import { z } from 'zod'
 
-// prettier-ignore
-const args = Command
-  .parameter(`filePath`, z.string().describe(`Path to the file to convert.`))
+const args = Command.parameter(`filePath`, z.string().describe(`Path to the file to convert.`))
   .parameter(`to`, z.enum([`json`, `yaml`, `toml`]).describe(`Format to convert to.`))
-  .parameter(
-    `from`,
-    z
-      .enum([`json`, `yaml`, `toml`])
-      .optional()
-      .describe(`Format to convert from. By default inferred from the file extension.`)
-  )
+  .parameter(`from`, {
+    schema: z.enum([`json`, `yaml`, `toml`]).optional(),
+    prompt: {
+      when: { result: `omitted` },
+    },
+  })
   .parameter(
     `verbose v`,
-    z.boolean().default(false).describe(`Log detailed progress as conversion executes.`)
+    z.boolean().default(false).describe(`Log detailed progress as conversion executes.`),
   )
   .parameter(
     `move m`,
-    z.boolean().default(false).describe(`Delete the original file after it has been converted.`)
+    z.boolean().default(false).describe(`Delete the original file after it has been converted.`),
   )
   .settings({
     prompt: {
       when: {
+        result: `rejected`,
         spec: { optionality: `required` },
       },
-    }
+    },
   })
   .parse()
 

--- a/packages/@molt/command/src/Settings/settings.ts
+++ b/packages/@molt/command/src/Settings/settings.ts
@@ -1,18 +1,20 @@
 import type { State } from '../Builder/State.js'
-import type { EventPatternsInput } from '../eventPatterns.js'
+import type { EventPatternsInput, EventPatternsInputAtLeastOne } from '../eventPatterns.js'
 import { eventPatterns } from '../eventPatterns.js'
+import type { Values } from '../helpers.js'
 import { parseEnvironmentVariableBooleanOrThrow } from '../helpers.js'
 import { defaultParameterNamePrefixes } from '../OpeningArgs/Environment/Environment.js'
+import type { ParameterSpec } from '../ParameterSpec/index.js'
 import type { FlagName } from '@molt/types'
 import snakeCase from 'lodash.snakecase'
 
 export type OnErrorReaction = 'exit' | 'throw'
 
-export type InputPrompt =
+export type InputPrompt<S extends ParameterSpec.Input.Schema> =
   | boolean
   | {
       enabled?: boolean
-      when?: EventPatternsInput
+      when?: EventPatternsInputAtLeastOne<S>
     }
 
 // eslint-disable-next-line
@@ -28,7 +30,7 @@ export interface Input<ParametersObject extends State.ParametersSchemaObjectBase
   }
   onError?: OnErrorReaction
   onOutput?: (output: string, defaultHandler: (output: string) => void) => void
-  prompt?: InputPrompt
+  prompt?: InputPrompt<Values<ParametersObject>>
   // prompt?:
   parameters?: {
     // prettier-ignore
@@ -45,7 +47,7 @@ export interface Input<ParametersObject extends State.ParametersSchemaObjectBase
 export interface Output {
   prompt: {
     enabled: boolean
-    when: EventPatternsInput
+    when: EventPatternsInput<ParameterSpec.Input.Schema>
   }
   description?: string | undefined
   help: boolean

--- a/packages/@molt/command/src/entrypoints/types.ts
+++ b/packages/@molt/command/src/entrypoints/types.ts
@@ -9,6 +9,5 @@ export namespace Methods {
       parameters: SomeParametersConfig<T>,
     ): SomeParametersConfig<T> => parameters
     export type InputAsConfig<T extends Schema> = SomeParametersConfig<T>
-    // export type Input = SomeParametersConfigSchema | SomeParametersConfig
   }
 }

--- a/packages/@molt/command/src/eventPatterns.ts
+++ b/packages/@molt/command/src/eventPatterns.ts
@@ -6,18 +6,15 @@ import type { z } from 'zod'
 
 // prettier-ignore
 export type EventPatternsInputAtLeastOne<Schema extends ParameterSpec.Input.Schema> =
-z.ZodFirstPartyTypeKind.ZodOptional extends Schema['_def']['typeName']  	? Pattern<BasicParameterParseEvent> :
-z.ZodFirstPartyTypeKind.ZodDefault  extends Schema['_def']['typeName']    ? Pattern<BasicParameterParseEvent> :
-// Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodOptional   	? Pattern<BasicParameterParseEvent> :
-// Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodDefault     ? Pattern<BasicParameterParseEvent> :
+  z.ZodFirstPartyTypeKind.ZodOptional extends Schema['_def']['typeName']  	? Pattern<BasicParameterParseEvent> :
+  z.ZodFirstPartyTypeKind.ZodDefault  extends Schema['_def']['typeName']    ? Pattern<BasicParameterParseEvent> :
+                                                                              Pattern<BasicParameterParseEventAccepted | BasicParameterParseEventRejected>
 
-                                                                            Pattern<BasicParameterParseEventAccepted | BasicParameterParseEventRejected>
+// prettier-ignore
 export type EventPatternsInput<Schema extends ParameterSpec.Input.Schema> =
-  Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodOptional
-    ? Pattern<BasicParameterParseEvent>
-    : Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodDefault
-    ? Pattern<BasicParameterParseEvent>
-    : Pattern<BasicParameterParseEventAccepted | BasicParameterParseEventRejected>
+  Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodOptional  ? Pattern<BasicParameterParseEvent> :
+  Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodDefault   ? Pattern<BasicParameterParseEvent> :
+                                                                            Pattern<BasicParameterParseEventAccepted | BasicParameterParseEventRejected>
 
 export type BasicParameterParseEvent =
   | BasicParameterParseEventAccepted

--- a/packages/@molt/command/src/eventPatterns.ts
+++ b/packages/@molt/command/src/eventPatterns.ts
@@ -5,10 +5,19 @@ import type { Pattern } from './Pattern/Pattern.js'
 import type { z } from 'zod'
 
 // prettier-ignore
-export type EventPatternsInput<Schema extends ParameterSpec.Input.Schema = ParameterSpec.Input.Schema> =
-  Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodOptional 	? Pattern<BasicParameterParseEvent> :
-  Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodDefault   ? Pattern<BasicParameterParseEvent> :
+export type EventPatternsInputAtLeastOne<Schema extends ParameterSpec.Input.Schema> =
+z.ZodFirstPartyTypeKind.ZodOptional extends Schema['_def']['typeName']  	? Pattern<BasicParameterParseEvent> :
+z.ZodFirstPartyTypeKind.ZodDefault  extends Schema['_def']['typeName']    ? Pattern<BasicParameterParseEvent> :
+// Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodOptional   	? Pattern<BasicParameterParseEvent> :
+// Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodDefault     ? Pattern<BasicParameterParseEvent> :
+
                                                                             Pattern<BasicParameterParseEventAccepted | BasicParameterParseEventRejected>
+export type EventPatternsInput<Schema extends ParameterSpec.Input.Schema> =
+  Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodOptional
+    ? Pattern<BasicParameterParseEvent>
+    : Schema['_def']['typeName'] extends z.ZodFirstPartyTypeKind.ZodDefault
+    ? Pattern<BasicParameterParseEvent>
+    : Pattern<BasicParameterParseEventAccepted | BasicParameterParseEventRejected>
 
 export type BasicParameterParseEvent =
   | BasicParameterParseEventAccepted

--- a/packages/@molt/command/tests/prompt/prompt.spec.ts
+++ b/packages/@molt/command/tests/prompt/prompt.spec.ts
@@ -89,7 +89,21 @@ it(`static error to match on omitted event on required parameter by .parameter(.
   // @ts-expect-error not available
   Command.parameter(`a`, { schema: s, prompt: { when: { result: `omitted` } } })
   // Is fine, because parameter is optional.
-  Command.parameter(`a`, { schema: s.optional(), prompt: { when: { result: `omitted` } } })
+  Command.parameter(`a`, {
+    schema: s.optional(),
+    prompt: { when: { result: `omitted` } },
+  })
+})
+
+it(`static error to match on omitted event on command level when no parameters have optional`, () => {
+  // @ts-expect-error not available
+  Command.parameter(`a`, { schema: s }).settings({ prompt: { when: { result: `omitted` } } })
+  // Is fine, because parameter is optional.
+  Command.parameter(`a`, { schema: s.optional() }).settings({ prompt: { when: { result: `omitted` } } })
+  // Is fine, because at least one parameter is optional.
+  Command.parameter(`a`, { schema: s.optional() })
+    .parameter(`b`, { schema: s })
+    .settings({ prompt: { when: { result: `omitted` } } })
 })
 
 /**


### PR DESCRIPTION
When no parameters are optional then "omitted" should not be allowed as
a result value.

closes #...

#### TASKS

- [ ] Out of band docs (website, README, ...)
- [ ] In of band docs (jsdoc)
- [ ] Tests
