### PR TITLE
fix(@molt/command): prompt settings enabled via object pass

### DIFF
--- a/packages/@molt/command/examples/intro.ts
+++ b/packages/@molt/command/examples/intro.ts
@@ -5,9 +5,6 @@ const args = Command.parameter(`filePath`, z.string().describe(`Path to the file
   .parameter(`to`, z.enum([`json`, `yaml`, `toml`]).describe(`Format to convert to.`))
   .parameter(`from`, {
     schema: z.enum([`json`, `yaml`, `toml`]).optional(),
-    prompt: {
-      when: { result: `omitted` },
-    },
   })
   .parameter(
     `verbose v`,
@@ -19,10 +16,15 @@ const args = Command.parameter(`filePath`, z.string().describe(`Path to the file
   )
   .settings({
     prompt: {
-      when: {
-        result: `rejected`,
-        spec: { optionality: `required` },
-      },
+      // TODO allow making parameter level opt-in or opt-out
+      // default: false,
+      when: [
+        {
+          result: `rejected`,
+          error: `ErrorMissingArgument`,
+        },
+        { result: `omitted` },
+      ],
     },
   })
   .parse()

--- a/packages/@molt/command/src/Settings/settings.ts
+++ b/packages/@molt/command/src/Settings/settings.ts
@@ -94,7 +94,11 @@ export const change = (current: Output, input: Input<{}>, environment: Environme
       current.prompt.enabled = input.prompt
     } else {
       if (input.prompt.enabled !== undefined) current.prompt.enabled = input.prompt.enabled
-      if (input.prompt.when !== undefined) current.prompt.when = input.prompt.when
+      if (input.prompt.when !== undefined) {
+        current.prompt.when = input.prompt.when
+        // Passing object makes enabled default to true
+        if (input.prompt.enabled === undefined) current.prompt.enabled = true
+      }
     }
   }
 

--- a/packages/@molt/command/tests/prompt/__snapshots__/settings.spec.ts.snap
+++ b/packages/@molt/command/tests/prompt/__snapshots__/settings.spec.ts.snap
@@ -25,6 +25,31 @@ exports[`can be stack of conditional prompts > tty strip ansi 1`] = `
 ]
 `;
 
+exports[`command level > passing object makes enabled default to true > args 1`] = `
+{
+  "a": "foo",
+  "help": false,
+}
+`;
+
+exports[`command level > passing object makes enabled default to true > tty 1`] = `
+[
+  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "foo",
+  "
+",
+]
+`;
+
+exports[`command level > passing object makes enabled default to true > tty strip ansi 1`] = `
+[
+  "1/1  a",
+  "foo",
+  "
+",
+]
+`;
+
 exports[`parameter defaults to custom settings > args 1`] = `
 {
   "a": "foo",

--- a/packages/@molt/command/tests/prompt/settings.spec.ts
+++ b/packages/@molt/command/tests/prompt/settings.spec.ts
@@ -22,6 +22,18 @@ describe(`parameter level`, () => {
   })
 })
 
+describe(`command level`, () => {
+  it(`passing object makes enabled default to true`, () => {
+    tty.mock.input.add([`foo`])
+    const args = Command.parameters({ a: { schema: s } })
+      .settings({ onError: `throw`, helpOnError: false, prompt: { when: { result: `rejected` } } })
+      .parse({ line: [], tty: tty.interface })
+    expect(args).toMatchSnapshot(`args`)
+    expect(tty.history.all).toMatchSnapshot(`tty`)
+    expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+  })
+})
+
 it(`prompt is disabled by default`, () => {
   const args = tryCatch(() =>
     Command.parameters({ a: { schema: s } })


### PR DESCRIPTION
closes #...

#### TASKS

- [ ] Out of band docs (website, README, ...)
- [ ] In of band docs (jsdoc)
- [ ] Tests
