### PR TITLE
feat(@molt/command)!: single create entrypoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
     // Disable this because it will conflict with ESLint based import organizing.
     "source.organizeImports": false
   },
-  "vitest.commandLine": ""
+  "vitest.commandLine": "",
+  "eslint.enable": false
 }

--- a/packages/@molt/command/README.md
+++ b/packages/@molt/command/README.md
@@ -1,4 +1,4 @@
-# @molt/command
+# @molt/Command
 
 🌱 Type-safe CLI command definition and execution.
 
@@ -68,30 +68,23 @@ npm add @molt/command zod
 import { Command } from '../src/index.js'
 import { z } from 'zod'
 
-// prettier-ignore
-const args = Command
-  .parameter(`filePath`, z
-    .string()
-    .describe(`Path to the file to convert.`)
+const args = Command.create()
+  .parameter(`filePath`, z.string().describe(`Path to the file to convert.`))
+  .parameter(`to`, z.enum([`json`, `yaml`, `toml`]).describe(`Format to convert to.`))
+  .parameter(
+    `from`,
+    z
+      .enum([`json`, `yaml`, `toml`])
+      .optional()
+      .describe(`Format to convert from. By default inferred from the file extension.`),
   )
-  .parameter(`to`, z
-     .enum([`json`, `yaml`, `toml`])
-     .describe(`Format to convert to.`)
+  .parameter(
+    `verbose v`,
+    z.boolean().default(false).describe(`Log detailed progress as conversion executes.`),
   )
-  .parameter(`from`, z
-     .enum([`json`, `yaml`, `toml`])
-     .optional()
-     .describe(`Format to convert from. By default inferred from the file extension.`)
-  )
-  .parameter(`verbose v`, z
-     .boolean()
-     .default(false)
-     .describe(`Log detailed progress as conversion executes.`)
-  )
-  .parameter(`move m`, z
-    .boolean()
-    .default(false)
-    .describe(`Delete the original file after it has been converted.`)
+  .parameter(
+    `move m`,
+    z.boolean().default(false).describe(`Delete the original file after it has been converted.`),
   )
   .parse()
 ```
@@ -266,14 +259,13 @@ args.quxLot === 'zoo'
 Duplicate parameter names will be caught statically via TypeScript.
 
 ```ts
-// prettier-ignore
-const args = Command
+const args = Command.create()
   .parameter('f foo bar', z.string())
-  .parameter('bar', z.string()) // <-- TS error: already taken
-  .parameter('f', z.string()) //   <-- TS error: already taken
-  .parameter('foo', z.string()) // <-- TS error: already taken
+  .parameter('bar', z.string()) //  <-- TS error: already taken
+  .parameter('f', z.string()) //    <-- TS error: already taken
+  .parameter('foo', z.string()) //  <-- TS error: already taken
   .parameter('help', z.string()) // <-- TS error: reserved name
-  .parameter('h', z.string()) // <-- TS error: reserved name
+  .parameter('h', z.string()) //    <-- TS error: reserved name
   .parse()
 ```
 
@@ -553,14 +545,13 @@ All you need to do is pass a _pattern_ to `prompt` either at the parameter level
 Each event type share some core properties but also have their own unique fields. For example with `Accepted` you can match against what the value given was and with `Rejected` you can match against the specific error that occurred.
 
 ```ts
-// prettier-ignore
-const args = Command
+const args = Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
     prompt: {
       result: 'rejected',
-      error: 'ErrorMissingArgument'
+      error: 'ErrorMissingArgument',
     },
   })
   .parse()
@@ -575,8 +566,7 @@ The pattern matching library will be open-sourced and thoroughly documented in t
 Passing `true` will enable using the default event pattern.
 
 ```ts
-// prettier-ignore
-const args = Command
+const args = Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
@@ -590,13 +580,13 @@ const args = Command
 You can enable prompt when one of the built-in event patterns occur:
 
 ```ts
-// prettier-ignore
-const args = Command.create().parameter(`filePath`, z.string())
+const args = Command.create()
+  .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
     prompt: {
-      when: Command.EventPatterns.rejectedMissingOrInvalid
-    }
+      when: Command.EventPatterns.rejectedMissingOrInvalid,
+    },
   })
   .parse()
 ```
@@ -604,13 +594,13 @@ const args = Command.create().parameter(`filePath`, z.string())
 Or when one of multiple events occurs:
 
 ```ts
-// prettier-ignore
-const args = Command.create().parameter(`filePath`, z.string())
+const args = Command.create()
+  .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
     prompt: {
       when: [Command.EventPatterns.rejectedMissingOrInvalid, Command.EventPatterns.omittedWithoutDefault],
-    }
+    },
   })
   .parse()
 ```
@@ -620,8 +610,8 @@ const args = Command.create().parameter(`filePath`, z.string())
 You can enable prompt when your given _event pattern_ occurs.
 
 ```ts
-// prettier-ignore
-const args = Command.create().parameter(`filePath`, z.string())
+const args = Command.create()
+  .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
     prompt: {
@@ -629,7 +619,7 @@ const args = Command.create().parameter(`filePath`, z.string())
         rejected: {
           reason: 'missing',
         },
-      }
+      },
     },
   })
   .parse()
@@ -642,8 +632,7 @@ You can configure prompts for the entire instance in the settings. The configura
 Enable explicitly with shorthand approach using a `boolean`:
 
 ```ts
-// prettier-ignore
-const args = Command
+const args = Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, z.enum([`json`, `yaml`, `toml`]))
   .settings({ prompt: true })
@@ -655,8 +644,7 @@ Enable explicitly with longhand approach using the `enabled` nested property and
 Note that in the following `enabled` could be omitted because passing an object implies `enabled: true` by default.
 
 ```ts
-// prettier-ignore
-const args = Command
+const args = Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, z.enum([`json`, `yaml`, `toml`]))
   .settings({
@@ -946,7 +934,7 @@ Here is an example where you might want this feature. You are building a CLI for
 
 ```ts
 // prettier-ignore
-const args = Command
+const args = Command.create()
   .parametersExclusive(`method`, (_) =>
     _.parameter(`v version`, z.string().regex(semverRegex()))
      .parameter(`b bump`, z.enum([`major`, `minor`, `patch`]))
@@ -985,7 +973,7 @@ By default, input for a group of mutually exclusive parameters is required. You 
 
 ```ts
 // prettier-ignore
-const args = Command
+const args = Command.create()
   .parametersExclusive(`method`, (_) =>
     _.parameter(`v version`, z.string().regex(semverRegex()))
      .parameter(`b bump`, z.enum([`major`, `minor`, `patch`]))
@@ -999,7 +987,7 @@ By default, input for a group of mutually exclusive parameters is required. You 
 
 ```ts
 // prettier-ignore
-const args = Command
+const args = Command.create()
   .parametersExclusive(`method`, (_) =>
     _.parameter(`v version`, z.string().regex(semverRegex()))
      .parameter(`b bump`, z.enum([`major`, `minor`, `patch`]))

--- a/packages/@molt/command/README.md
+++ b/packages/@molt/command/README.md
@@ -118,7 +118,8 @@ $ mybin --help
 - Normalization between camel and kebab case and optional dash prefix:
 
   ```ts
-  const args = Command.parameter('--do-it-a', z.boolean())
+  const args = Command.create()
+    .parameter('--do-it-a', z.boolean())
     .parameter('--doItB', z.boolean())
     .parameter('doItC', z.boolean())
     .parse()
@@ -131,13 +132,13 @@ $ mybin --help
 - Specify one or multiple (aka. aliases) short and long flags:
 
   ```ts
-  Command.parameter('-f --force --forcefully', z.boolean()).parse()
+  Command.create().parameter('-f --force --forcefully', z.boolean()).parse()
   ```
 
 - Use Zod `.default(...)` method for setting default values.
 
   ```ts
-  const args = Command.parameter('--path', z.string().default('./a/b/c')).parse()
+  const args = Command.create().parameter('--path', z.string().default('./a/b/c')).parse()
   args.path === './a/b/c/' //   $ mybin
   args.path === '/over/ride' // $ mybin --path /over/ride
   ```
@@ -151,7 +152,7 @@ $ mybin --help
   - Pass via environment variables (customizable)
 
     ```ts
-    const args = Command.parameter('--path', z.string()).parse()
+    const args = Command.create().parameter('--path', z.string()).parse()
     args.path === './a/b/c/' // $ CLI_PARAM_PATH='./a/b/c' mybin
     ```
 
@@ -183,7 +184,8 @@ A [video introduction](https://www.youtube.com/watch?v=UtXM4FKCUDo) if you like 
 You can define parameters as a zod object schema using regular property names. These are flags for your CLI but arguments can also be passed by environment variables so in a way this is a neutral form that doesn't privilege either argument passing mechanism.
 
 ```ts
-const args = Command.parameter('foo', z.string())
+const args = Command.create()
+  .parameter('foo', z.string())
   .parameter('bar', z.number())
   .parameter('qux', z.boolean())
   .parse()
@@ -198,7 +200,8 @@ args.qux
 You can also define them using flag syntax if you prefer. Thanks to `@molt/types` this style doesn't sacrifice any type safety.
 
 ```ts
-const args = Command.parameter('--foo', z.string())
+const args = Command.create()
+  .parameter('--foo', z.string())
   .parameter('--bar', z.number())
   .parameter('--qux', z.boolean())
   .parse()
@@ -218,7 +221,8 @@ A set of parameter names gets normalized into its canonical name internally (aga
 2. Otherwise the first short flag
 
 ```ts
-const args = Command.parameter('--foobar --foo -f ', z.string())
+const args = Command.create()
+  .parameter('--foobar --foo -f ', z.string())
   .parameter('--bar -b -x', z.number())
   .parameter('-q --qux', z.boolean())
   .parameter('-m -n', z.boolean())
@@ -236,7 +240,8 @@ args.m === true
 If you prefer you can use a dash-prefix free syntax:
 
 ```ts
-const args = Command.parameter('foobar foo f ', z.string())
+const args = Command.create()
+  .parameter('foobar foo f ', z.string())
   .parameter('bar b x', z.number())
   .parameter('q qux', z.boolean())
   .parameter('m n', z.boolean())
@@ -248,7 +253,7 @@ const args = Command.parameter('foobar foo f ', z.string())
 You can use kebab or camel case (and likewise your users can pass flags in either style). Canonical form internally uses camel case.
 
 ```ts
-const args = Command.parameter('foo-bar', z.string()).parameter('quxLot', z.string()).parse()
+const args = Command.create().parameter('foo-bar', z.string()).parameter('quxLot', z.string()).parse()
 
 // $ mybin --foo-bar moo --qux-lot zoo
 // $ mybin --fooBar moo --quxLot zoo
@@ -315,7 +320,7 @@ z.string().min(1).describe('...').optional()
 Examples:
 
 ```ts
-const args = Command.parameter('f force forcefully', z.boolean()).parse()
+const args = Command.create().parameter('f force forcefully', z.boolean()).parse()
 // $ CLI_PARAM_NO_F='true' mybin
 // $ CLI_PARAM_NO_FORCE='true' mybin
 // $ CLI_PARAM_NO_FORCEFULLY='true' mybin
@@ -386,7 +391,7 @@ args.force === true
 - If one variant is a boolean then flag will interpret no argument as being an argument of the boolean variant. For example given this CLI:
 
   ```ts
-  Command.parameter('xee', z.union([z.boolean(), z.number()]))
+  Command.create().parameter('xee', z.union([z.boolean(), z.number()]))
   ```
 
   A user could call your CLI in any of these ways:
@@ -400,7 +405,7 @@ args.force === true
 - When a parameter is a union type, the variant that can first successfully parse the given value becomes the interpreted type for the given value. Variant parsers are tried in order of most specific to least, which is: `enum`, `number`, `boolean`, `string`. So for example if you had a union parameter like this:
 
   ```ts
-  Command.parameter('xee', z.union([z.string(), z.number()]))
+  Command.create().parameter('xee', z.union([z.string(), z.number()]))
   ```
 
 ##### Help Rendering
@@ -408,7 +413,7 @@ args.force === true
 - By default help rendering will render something like so:
 
   ```ts
-  Command.parameter('xee', z.union([z.string(), z.number()]).description('Blah blah blah.'))
+  Command.create().parameter('xee', z.union([z.string(), z.number()]).description('Blah blah blah.'))
   ```
 
   ```
@@ -423,7 +428,7 @@ args.force === true
 - When the parameters have descriptions then it will cause an expanded layout e.g.:
 
   ```ts
-  Command.parameter(
+  Command.create().parameter(
     'xee',
     z
       .union([
@@ -453,7 +458,8 @@ args.force === true
 - You can force expanded layout even when parameters do not have descriptions via the settings, e.g.:
 
   ```ts
-  Command.parameter('xee', z.union([z.string(), z.number()]))
+  Command.create()
+    .parameter('xee', z.union([z.string(), z.number()]))
     .parameter('foo', z.union([z.string(), z.number()]))
     .settings({
       helpRendering: {
@@ -585,7 +591,7 @@ You can enable prompt when one of the built-in event patterns occur:
 
 ```ts
 // prettier-ignore
-const args = Command.parameter(`filePath`, z.string())
+const args = Command.create().parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
     prompt: {
@@ -599,7 +605,7 @@ Or when one of multiple events occurs:
 
 ```ts
 // prettier-ignore
-const args = Command.parameter(`filePath`, z.string())
+const args = Command.create().parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
     prompt: {
@@ -615,7 +621,7 @@ You can enable prompt when your given _event pattern_ occurs.
 
 ```ts
 // prettier-ignore
-const args = Command.parameter(`filePath`, z.string())
+const args = Command.create().parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
     prompt: {
@@ -731,7 +737,7 @@ CLI_PARAM_{parameter_name}
 ```
 
 ```ts
-const args = Command.parameter('--path', z.string()).parse()
+const args = Command.create().parameter('--path', z.string()).parse()
 args.path === './a/b/c/' // $ CLI_PARAMETER_PATH='./a/b/c' mybin
 ```
 
@@ -740,7 +746,7 @@ args.path === './a/b/c/' // $ CLI_PARAMETER_PATH='./a/b/c' mybin
 You can toggle environment arguments on/off. It is on by default.
 
 ```ts
-const command = Command.parameter('--path', z.string()).settings({
+const command = Command.create().parameter('--path', z.string()).settings({
   environment: false,
 })
 // $ CLI_PARAMETER_PATH='./a/b/c' mybin
@@ -751,7 +757,7 @@ command.parse()
 You can also toggle with the environment variable `CLI_SETTINGS_READ_ARGUMENTS_FROM_ENVIRONMENT` (case insensitive):
 
 ```ts
-const command = Command.parameter('--path', z.string())
+const command = Command.create().parameter('--path', z.string())
 // $ CLI_SETTINGS_READ_ARGUMENTS_FROM_ENVIRONMENT='false' CLI_PARAMETER_PATH='./a/b/c' mybin
 // Throws error because no argument given for "path"
 command.parse()
@@ -762,7 +768,8 @@ command.parse()
 You can toggle environment on for just one or some parameters.
 
 ```ts
-const args = Command.parameter('--foo', z.string())
+const args = Command.create()
+  .parameter('--foo', z.string())
   .parameter('--bar', z.string().default('not_from_env'))
   .settings({ environment: { foo: true } })
   .parse()
@@ -775,7 +782,8 @@ args.bar === 'not_from_env'
 You can toggle environment on except for just one or some parameters.
 
 ```ts
-const args = Command.parameter('--foo', z.string().default('not_from_env'))
+const args = Command.create()
+  .parameter('--foo', z.string().default('not_from_env'))
   .parameter('--bar', z.string().default('not_from_env'))
   .parameter('--qux', z.string().default('not_from_env'))
   .settings({ environment: { $default: true, bar: false } })
@@ -792,7 +800,8 @@ args.qux === 'qux'
 You can customize the environment variable name prefix:
 
 ```ts
-const args = Command.parameter('--path', z.string())
+const args = Command.create()
+  .parameter('--path', z.string())
   //                                              o-- case insensitive
   .settings({ environment: { $default: { prefix: 'foo' } } })
   .parse()
@@ -803,7 +812,8 @@ args.path === './a/b/c/' // $ FOO_PATH='./a/b/c' mybin
 You can pass a list of accepted prefixes instead of just one. Earlier ones take precedence over later ones:
 
 ```ts
-const args = Command.parameter('--path', z.string())
+const args = Command.create()
+  .parameter('--path', z.string())
   //                                               o---------o--- case insensitive
   .settings({ environment: { $default: { prefix: ['foobar', 'foo'] } } })
   .parse()
@@ -818,7 +828,8 @@ args.path === './a/b/c/' // $ FOO_PATH='./x/y/z' FOOBAR_PATH='./a/b/c' mybin
 You can customize the environment variable name prefix for just one or some parameters.
 
 ```ts
-const args = Command.parameter('--foo', z.string().default('not_from_env'))
+const args = Command.create()
+  .parameter('--foo', z.string().default('not_from_env'))
   .parameter('--bar', z.string().default('not_from_env'))
   .parameter('--qux', z.string().default('not_from_env'))
   .settings({ environment: { bar: { prefix: 'MOO' } } })
@@ -833,7 +844,8 @@ args.qux === 'qux'
 You can customize the environment variable name prefix except for just one or some parameters.
 
 ```ts
-const args = Command.parameter('--foo', z.string().default('not_from_env'))
+const args = Command.create()
+  .parameter('--foo', z.string().default('not_from_env'))
   .parameter('--bar', z.string().default('not_from_env'))
   .parameter('--qux', z.string().default('not_from_env'))
   .settings({ environment: { $default: { enabled: true, prefix: 'MOO' }, bar: { prefix: true } } })
@@ -850,7 +862,8 @@ args.qux === 'qux'
 You can remove the prefix altogether. Pretty and convenient, but be careful for unexpected use of variables in host environment that would affect your CLI execution!
 
 ```ts
-const args = Command.parameter('--path', z.string())
+const args = Command.create()
+  .parameter('--path', z.string())
   .settings({ environment: { $default: { prefix: false } } })
   .parse()
 
@@ -862,7 +875,8 @@ args.path === './a/b/c/' // $ PATH='./a/b/c' mybin
 You can disable environment variable name prefixes for just one or some parameters.
 
 ```ts
-const args = Command.parameter('--foo', z.string().default('not_from_env'))
+const args = Command.create()
+  .parameter('--foo', z.string().default('not_from_env'))
   .parameter('--bar', z.string().default('not_from_env'))
   .parameter('--qux', z.string().default('not_from_env'))
   .settings({ environment: { bar: { prefix: false } } })
@@ -877,7 +891,8 @@ args.qux === 'qux'
 You can disable environment variable name prefixes except for just one or some parameters.
 
 ```ts
-const args = Command.parameter('--foo', z.string().default('not_from_env'))
+const args = Command.create()
+  .parameter('--foo', z.string().default('not_from_env'))
   .parameter('--bar', z.string().default('not_from_env'))
   .parameter('--qux', z.string().default('not_from_env'))
   .settings({ environment: { $default: { enabled: true, prefix: false }, bar: { prefix: true } } })
@@ -894,7 +909,7 @@ args.qux === 'qux'
 Environment variables are considered in a case insensitive way so all of these work:
 
 ```ts
-const args = Command.parameter('--path', z.string()).parse()
+const args = Command.create().parameter('--path', z.string()).parse()
 // $ CLI_PARAM_PATH='./a/b/c' mybin
 // $ cli_param_path='./a/b/c' mybin
 // $ cLi_pAraM_paTh='./a/b/c' mybin
@@ -906,7 +921,7 @@ args.path === './a/b/c/'
 By default, when a prefix is defined, a typo will raise an error:
 
 ```ts
-const command = Command.parameter('--path', z.string())
+const command = Command.create().parameter('--path', z.string())
 
 // $ CLI_PARAM_PAH='./a/b/c' mybin
 // Throws error because there is no parameter named "pah" defined.
@@ -916,7 +931,7 @@ command.parse()
 If you pass arguments for a parameter multiple times under different environment variable name aliases an error will be raised.
 
 ```ts
-const command = Command.parameter('--path', z.string())
+const command = Command.create().parameter('--path', z.string())
 
 // $ CLI_PARAMETER_PAH='./1/2/3' CLI_PARAM_PAH='./a/b/c' mybin
 /ole/ Throws error because user intent is ambiguous.
@@ -1004,9 +1019,11 @@ Your users will clearly see that these parameters are mutually exclusive. Here's
 You can give your command a description similar to how you can give each of your parameters a description.
 
 ```ts
-const args = Command.description(
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.',
-).parameter(/* ... */)
+const args = Command.create()
+  .description(
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.',
+  )
+  .parameter(/* ... */)
 ```
 
 Descriptions will show up in the auto generated help.
@@ -1038,7 +1055,7 @@ mybin --xee z     <-- enable xee using z
 You could achieve this with the following parameter definition:
 
 ```ts
-const args = Command.parameter('xee', z.union([z.boolean(), z.enum(['x', 'y', 'z'])]).default(false))
+const args = Command.create().parameter('xee', z.union([z.boolean(), z.enum(['x', 'y', 'z'])]).default(false))
 
 args.xee // type: false | true | 'x' | 'y' | 'z'
 ```

--- a/packages/@molt/command/examples/intro.ts
+++ b/packages/@molt/command/examples/intro.ts
@@ -1,7 +1,8 @@
 import { Command } from '../src/index.js'
 import { z } from 'zod'
 
-const args = Command.parameter(`filePath`, z.string().describe(`Path to the file to convert.`))
+const args = Command.create()
+  .parameter(`filePath`, z.string().describe(`Path to the file to convert.`))
   .parameter(`to`, z.enum([`json`, `yaml`, `toml`]).describe(`Format to convert to.`))
   .parameter(`from`, {
     schema: z.enum([`json`, `yaml`, `toml`]).optional(),

--- a/packages/@molt/command/examples/kitchen-sink.ts
+++ b/packages/@molt/command/examples/kitchen-sink.ts
@@ -1,9 +1,10 @@
 import { Command } from '../src/index.js'
 import { z } from 'zod'
 
-const args = Command.description(
-  `This is a so-called "kitchen-sink" Molt Command example. Many features are demonstrated here though the overall CLI itself makes no sense. Take a look around, see how the help renders, try running with different inputs, etc.`,
-)
+const args = Command.create()
+  .description(
+    `This is a so-called "kitchen-sink" Molt Command example. Many features are demonstrated here though the overall CLI itself makes no sense. Take a look around, see how the help renders, try running with different inputs, etc.`,
+  )
   .parameter(
     `badDefault`,
     z.string().default(() => {

--- a/packages/@molt/command/examples/publish.ts
+++ b/packages/@molt/command/examples/publish.ts
@@ -2,15 +2,15 @@ import { Command } from '../src/index.js'
 import semverRegex from 'semver-regex'
 import { z } from 'zod'
 
-// prettier-ignore
-const args = Command
+const args = Command.create()
   .parameter(`githubToken`, z.string())
   .parameter(`publish`, z.boolean().default(true))
   .parameter(`githubRelease`, z.boolean().default(true))
   .parameter(`p package`, z.enum([`@molt/command`, `@molt/types`, `molt`]))
   .parametersExclusive(`method`, (__) =>
+    // prettier-ignore
     __.parameter(`v version`, z.string().regex(semverRegex()))
-      .parameter(`b bump`, z.enum([`major`, `minor`, `patch`]))
+      .parameter(`b bump`, z.enum([`major`, `minor`, `patch`])),
   )
   .settings({
     parameters: {

--- a/packages/@molt/command/src/Builder/root/runtime.ts
+++ b/packages/@molt/command/src/Builder/root/runtime.ts
@@ -5,7 +5,7 @@ import { Settings } from '../../Settings/index.js'
 import * as ExclusiveBuilder from '../exclusive/constructor.js'
 import type { ParameterConfiguration, RawArgInputs, RootBuilder } from './types.js'
 
-const create = () => {
+export const create = (): RootBuilder => {
   const $: State = {
     newSettingsBuffer: [],
     settings: null,
@@ -67,20 +67,8 @@ const create = () => {
     },
   }
 
-  return chain
+  return chain as any
 }
-
-// prettier-ignore
-// @ts-expect-error internal to external
-export const createViaParametersExclusive: RootBuilder['parametersExclusive'] = (...args) => create().parametersExclusive(...args)
-
-// prettier-ignore
-// @ts-expect-error internal to external
-export const createViaParameter: RootBuilder['parameter'] = (...args) => create().parameter(...args)
-
-// prettier-ignore
-// @ts-expect-error internal to external
-export const createViaDescription: RootBuilder['description'] = (...args) => create().description(...args)
 
 //
 // Internal Types

--- a/packages/@molt/command/src/index_.ts
+++ b/packages/@molt/command/src/index_.ts
@@ -1,6 +1,2 @@
-export {
-  createViaDescription as description,
-  createViaParameter as parameter,
-  createViaParametersExclusive as parametersExclusive,
-} from './Builder/root/runtime.js'
+export { create } from './Builder/root/runtime.js'
 export { eventPatterns } from './eventPatterns.js'

--- a/packages/@molt/command/tests/chaining/chaining.spec.ts
+++ b/packages/@molt/command/tests/chaining/chaining.spec.ts
@@ -9,35 +9,35 @@ describe(`errors`, () => {
   describe(`reserved flag`, () => {
     it(`help`, () => {
       // @ts-expect-error test
-      Command.parameter(`help`, s)
+      Command.create().parameter(`help`, s)
     })
     it(`help`, () => {
       // @ts-expect-error test
-      Command.parameter(`h`, s)
+      Command.create().parameter(`h`, s)
     })
     it(`h help`, () => {
       // @ts-expect-error test
-      Command.parameter(`h help`, s)
+      Command.create().parameter(`h help`, s)
     })
   })
   describe(`reuse flag`, () => {
     it(`long flag`, () => {
-      c = Command.parameter(`alpha`, s)
+      c = Command.create().parameter(`alpha`, s)
       // @ts-expect-error test
       c.parameter(`alpha`, s)
     })
     it(`long flag alias`, () => {
-      c = Command.parameter(`alpha bravo`, s)
+      c = Command.create().parameter(`alpha bravo`, s)
       // @ts-expect-error test
       c.parameter(`bravo`, s)
     })
     it(`short flag`, () => {
-      c = Command.parameter(`a`, s)
+      c = Command.create().parameter(`a`, s)
       // @ts-expect-error test
       c.parameter(`a`, s)
     })
     it(`short flag alias`, () => {
-      c = Command.parameter(`a b`, s)
+      c = Command.create().parameter(`a b`, s)
       // @ts-expect-error test
       c.parameter(`b`, s)
     })
@@ -45,7 +45,8 @@ describe(`errors`, () => {
 })
 
 it(`works`, () => {
-  const args = Command.parameter(`foo`, z.string())
+  const args = Command.create()
+    .parameter(`foo`, z.string())
     .parameter(`bar`, z.string())
     .parse({ line: [`--foo`, `1`, `--bar`, `2`] })
   expect(args).toMatchObject({ foo: `1`, bar: `2` })

--- a/packages/@molt/command/tests/environment/case.spec.ts
+++ b/packages/@molt/command/tests/environment/case.spec.ts
@@ -6,12 +6,12 @@ import { it } from 'vitest'
 
 it(`snake case environment variables are matched to parameters`, () => {
   environmentManager.set(`cli_param_foo_bar`, `toto`)
-  const args = Command.parameter(`fooBar`, s).parse({ line: [] })
+  const args = Command.create().parameter(`fooBar`, s).parse({ line: [] })
   expect(args).toMatchObject({ fooBar: `toto` })
 })
 
 it(`environment variables are read case insensitive`, () => {
   environmentManager.set(`CLI_param_fOo_bAR`, `toto`)
-  const args = Command.parameter(`fooBar`, s).parse({ line: [] })
+  const args = Command.create().parameter(`fooBar`, s).parse({ line: [] })
   expect(args).toMatchObject({ fooBar: `toto` })
 })

--- a/packages/@molt/command/tests/environment/global/prefix.spec.ts
+++ b/packages/@molt/command/tests/environment/global/prefix.spec.ts
@@ -6,26 +6,30 @@ import { beforeEach, expect } from 'vitest'
 import { describe, it } from 'vitest'
 
 it(`can be disabled`, () => {
-  const args = Command.parameter(`--foo`, s)
+  const args = Command.create()
+    .parameter(`--foo`, s)
     .settings({ parameters: { environment: { $default: { prefix: false } } } })
     .parse({ line: [], environment: { foo: `bar` } })
   expect(args).toMatchObject({ foo: `bar` })
 })
 it(`can be customized to a different prefix`, () => {
-  const args = Command.parameter(`--foo`, s)
+  const args = Command.create()
+    .parameter(`--foo`, s)
     .settings({ parameters: { environment: { $default: { prefix: `FOO` } } } })
     .parse({ line: [], environment: { FOO_foo: `bar` } })
   expect(args).toMatchObject({ foo: `bar` })
 })
 it(`can be customized to multiple accepted different prefixes`, () => {
-  const args = Command.parameter(`--foo`, s)
+  const args = Command.create()
+    .parameter(`--foo`, s)
     .parameter(`--bar`, s)
     .settings({ parameters: { environment: { $default: { prefix: [`FOO`, `BAR`] } } } })
     .parse({ line: [], environment: { FOO_foo: `qux1`, BAR_bar: `qux2` } })
   expect(args).toMatchObject({ foo: `qux1`, bar: `qux2` })
 })
 it(`defaults to CLI_PARAM or CLI_PARAMETERS`, () => {
-  const args = Command.parameter(`--foo`, s)
+  const args = Command.create()
+    .parameter(`--foo`, s)
     .parameter(`--bar`, s)
     .parse({
       line: [],
@@ -39,14 +43,16 @@ it(`defaults to CLI_PARAM or CLI_PARAMETERS`, () => {
 describe(`error`, () => {
   it(`when using prefix and there is a typo`, () => {
     // TODO show not just envar prefix in error message json
-    Command.parameter(`--foo`, s)
+    Command.create()
+      .parameter(`--foo`, s)
       .settings({ helpOnNoArguments: false })
       .parse({ line: [], environment: { cli_param_bar: `qux1` } })
     expect(stdout.mock.calls).toMatchSnapshot()
   })
   it(`when using multiple prefixes and args passed for all param variations`, () => {
     // TODO show not just envar prefix in error message json
-    Command.parameter(`--foo`, s)
+    Command.create()
+      .parameter(`--foo`, s)
       .parameter(`--bar`, s)
       .parse({
         line: [],
@@ -67,18 +73,18 @@ describe(`default environment argument parameter name prefix`, () => {
 
   it(`argument can be passed by CLI_PARAMETER prefix`, () => {
     environmentManager.set(`cli_parameter_foo`, `bar`)
-    const args = Command.parameter(`--foo`, s).parse({ line: [] })
+    const args = Command.create().parameter(`--foo`, s).parse({ line: [] })
     expect(args).toMatchObject({ foo: `bar` })
   })
   it(`argument can be passed by CLI_PARAM prefix`, () => {
     environmentManager.set(`cli_param_foo`, `bar`)
-    const args = Command.parameter(`--foo`, s).parse({ line: [] })
+    const args = Command.create().parameter(`--foo`, s).parse({ line: [] })
     expect(args).toMatchObject({ foo: `bar` })
   })
   it(`when both argument CLI_PARAM and CLI_PARAMETER are passed then an error is thrown`, () => {
     environmentManager.set(`cli_param_foo`, `bar1`)
     environmentManager.set(`cli_parameter_foo`, `bar2`)
-    Command.parameter(`--foo`, s).settings({ helpOnNoArguments: false }).parse({ line: [] })
+    Command.create().parameter(`--foo`, s).settings({ helpOnNoArguments: false }).parse({ line: [] })
     expect(stdout.mock.calls).toMatchSnapshot()
   })
 })

--- a/packages/@molt/command/tests/environment/global/toggling.spec.ts
+++ b/packages/@molt/command/tests/environment/global/toggling.spec.ts
@@ -10,20 +10,23 @@ const output = createState<string>({
 
 it(`is enabled by default`, () => {
   environmentManager.set(`cli_parameter_foo`, `bar`)
-  const args = Command.parameter(`--foo`, s).parse({ line: [] })
+  const args = Command.create().parameter(`--foo`, s).parse({ line: [] })
   expect(args).toMatchObject({ foo: `bar` })
 })
 it(`can be enabled by settings`, () => {
   environmentManager.set(`cli_param_foo`, `bar`)
-  const args1 = Command.parameter(`--foo`, s)
+  const args1 = Command.create()
+    .parameter(`--foo`, s)
     .settings({ parameters: { environment: true } })
     .parse({ line: [] })
   expect(args1).toMatchObject({ foo: `bar` })
-  const args2 = Command.parameter(`--foo`, s)
+  const args2 = Command.create()
+    .parameter(`--foo`, s)
     .settings({ parameters: { environment: { $default: true } } })
     .parse({ line: [] })
   expect(args2).toMatchObject({ foo: `bar` })
-  const args3 = Command.parameter(`--foo`, s)
+  const args3 = Command.create()
+    .parameter(`--foo`, s)
     .settings({ parameters: { environment: { $default: { enabled: true } } } })
     .parse({ line: [] })
   expect(args3).toMatchObject({ foo: `bar` })
@@ -31,18 +34,19 @@ it(`can be enabled by settings`, () => {
 it(`can be enabled by environment`, () => {
   environmentManager.set(`ClI_settings_READ_arguments_FROM_ENVIRONMENT`, `true`)
   environmentManager.set(`cli_param_foo`, `bar`)
-  const args = Command.parameter(`--foo`, s).parse({ line: [] })
+  const args = Command.create().parameter(`--foo`, s).parse({ line: [] })
   expect(args).toMatchObject({ foo: `bar` })
 })
 it(`can be disabled by environment`, () => {
   environmentManager.set(`ClI_settings_READ_arguments_FROM_ENVIRONMENT`, `false`)
   environmentManager.set(`cli_param_foo`, `foo_env`)
-  const args = Command.parameter(`--foo`, s.default(`foo_default`)).parse({ line: [] })
+  const args = Command.create().parameter(`--foo`, s.default(`foo_default`)).parse({ line: [] })
   expect(args).toMatchObject({ foo: `foo_default` })
 })
 it(`environment supersedes settings`, () => {
   expect(() =>
-    Command.parameter(`--foo`, s)
+    Command.create()
+      .parameter(`--foo`, s)
       .settings({
         onOutput: output.set,
         parameters: { environment: true },

--- a/packages/@molt/command/tests/environment/parsing.spec.ts
+++ b/packages/@molt/command/tests/environment/parsing.spec.ts
@@ -11,51 +11,51 @@ beforeEach(() => environmentManager.set(`CLI_SETTINGS_READ_ARGUMENTS_FROM_ENVIRO
 describe(`boolean can be parsed`, () => {
   it(`parses value of true`, () => {
     environmentManager.set(`CLI_PARAM_VERBOSE`, `true`)
-    const args = Command.parameter(`--verbose`, b).parse({ line: [] })
+    const args = Command.create().parameter(`--verbose`, b).parse({ line: [] })
     expect(args).toMatchObject({ verbose: true })
   })
   it(`parses value of true which overrides a spec default of false`, () => {
     environmentManager.set(`CLI_PARAM_VERBOSE`, `true`)
-    const args = Command.parameter(`--verbose`, b.default(false)).parse({ line: [] })
+    const args = Command.create().parameter(`--verbose`, b.default(false)).parse({ line: [] })
     expect(args).toMatchObject({ verbose: true })
   })
   it(`parses value of false`, () => {
     environmentManager.set(`cli_param_verbose`, `false`)
-    const args = Command.parameter(`--verbose`, b).parse({ line: [] })
+    const args = Command.create().parameter(`--verbose`, b).parse({ line: [] })
     expect(args).toMatchObject({ verbose: false })
   })
   describe(`alias`, () => {
     it(`parses value of true`, () => {
       environmentManager.set(`cli_param_VERB`, `true`)
-      const args = Command.parameter(`--verbose --verb`, z.boolean()).parse({ line: [] })
+      const args = Command.create().parameter(`--verbose --verb`, z.boolean()).parse({ line: [] })
       expect(args).toMatchObject({ verbose: true })
     })
     it(`parses value of false`, () => {
       environmentManager.set(`cli_param_VERB`, `false`)
-      const args = Command.parameter(`--verbose --verb`, z.boolean()).parse({ line: [] })
+      const args = Command.create().parameter(`--verbose --verb`, z.boolean()).parse({ line: [] })
       expect(args).toMatchObject({ verbose: false })
     })
   })
   describe(`negated`, () => {
     it(`parses negated name with false value`, () => {
       environmentManager.set(`cli_param_no_foo`, `false`)
-      const args = Command.parameter(`--foo`, z.boolean()).parse({ line: [] })
+      const args = Command.create().parameter(`--foo`, z.boolean()).parse({ line: [] })
       expect(args).toMatchObject({ foo: true })
     })
     it(`parses negated name with true value`, () => {
       environmentManager.set(`cli_param_no_foo`, `true`)
-      const args = Command.parameter(`--foo`, z.boolean()).parse({ line: [] })
+      const args = Command.create().parameter(`--foo`, z.boolean()).parse({ line: [] })
       expect(args).toMatchObject({ foo: false })
     })
     describe(`alias`, () => {
       it(`parses negated alias name with true value`, () => {
         environmentManager.set(`cli_param_no_foobar`, `true`)
-        const args = Command.parameter(`--foo --foobar`, b).parse({ line: [] })
+        const args = Command.create().parameter(`--foo --foobar`, b).parse({ line: [] })
         expect(args).toMatchObject({ foo: false })
       })
       it(`parses negated alias name with false value`, () => {
         environmentManager.set(`cli_param_no_foobar`, `false`)
-        const args = Command.parameter(`--foo --foobar`, b).parse({ line: [] })
+        const args = Command.create().parameter(`--foo --foobar`, b).parse({ line: [] })
         expect(args).toMatchObject({ foo: true })
       })
     })
@@ -64,25 +64,27 @@ describe(`boolean can be parsed`, () => {
 
 it(`parses a value specified to be a string`, () => {
   environmentManager.set(`cli_param_foo`, `bar`)
-  const args = Command.parameter(`--foo`, s).parse({ line: [] })
+  const args = Command.create().parameter(`--foo`, s).parse({ line: [] })
   expect(args).toMatchObject({ foo: `bar` })
 })
 it(`parses a value specified to be a number`, () => {
   environmentManager.set(`cli_param_foo`, `4.3`)
-  const args = Command.parameter(`--foo`, n).parse({ line: [] })
+  const args = Command.create().parameter(`--foo`, n).parse({ line: [] })
   expect(args).toMatchObject({ foo: 4.3 })
 })
 describe(`enum can be parsed`, () => {
   it(`throws an error if the value does not pass validation`, () => {
     environmentManager.set(`cli_param_foo`, `d`)
-    Command.parameter(`--foo`, z.enum([`a`, `b`, `c`])).parse({ line: [] })
+    Command.create()
+      .parameter(`--foo`, z.enum([`a`, `b`, `c`]))
+      .parse({ line: [] })
     expect(stdout.mock.calls).toMatchSnapshot()
   })
 })
 
 it(`ignores the letter casing of env name`, () => {
   environmentManager.set(`cLi_PARAM_fOo`, `bar`)
-  const args = Command.parameter(`--foo`, s).parse({ line: [] })
+  const args = Command.create().parameter(`--foo`, s).parse({ line: [] })
   expect(args).toMatchObject({ foo: `bar` })
 })
 

--- a/packages/@molt/command/tests/environment/selective/prefix.spec.ts
+++ b/packages/@molt/command/tests/environment/selective/prefix.spec.ts
@@ -10,7 +10,8 @@ it(`just one can have prefix disabled`, () => {
     foo: `foo`,
     cli_param_bar: `bar-prefix`,
   })
-  const args = Command.parameter(`--foo`, s)
+  const args = Command.create()
+    .parameter(`--foo`, s)
     .parameter(`--bar`, z.string())
     .settings({ parameters: { environment: { $default: true, foo: { prefix: false } } } })
     .parse({ line: [] })
@@ -22,7 +23,8 @@ it(`all but one can have prefix disabled`, () => {
     bar: `bar`,
     cli_param_foo: `cli_param_foo`,
   })
-  const args = Command.parameter(`--foo`, s)
+  const args = Command.create()
+    .parameter(`--foo`, s)
     .parameter(`--bar`, s)
     .settings({
       parameters: { environment: { $default: { enabled: true, prefix: false }, foo: { prefix: true } } },

--- a/packages/@molt/command/tests/environment/selective/toggling.spec.ts
+++ b/packages/@molt/command/tests/environment/selective/toggling.spec.ts
@@ -6,7 +6,8 @@ import { describe, expect, it } from 'vitest'
 it(`can toggle environment on for one parameter`, () => {
   environmentManager.set(`cli_param_foo`, `env1`)
   environmentManager.set(`cli_param_bar`, `env2`)
-  const args = Command.parameter(`--foo`, s.default(`foo`))
+  const args = Command.create()
+    .parameter(`--foo`, s.default(`foo`))
     .parameter(`--bar`, s.default(`bar`))
     .settings({ parameters: { environment: { foo: true } } })
     .parse({ line: [] })
@@ -16,7 +17,8 @@ it(`can toggle environment on for one parameter`, () => {
 it(`can change prefix for one parameter`, () => {
   environmentManager.set(`foo`, `foo_env`)
   environmentManager.set(`cli_param_bar`, `bar_env`)
-  const args = Command.parameter(`--foo`, s.default(`foo_default`))
+  const args = Command.create()
+    .parameter(`--foo`, s.default(`foo_default`))
     .parameter(`--bar`, s.default(`bar_default`))
     .settings({ parameters: { environment: { foo: { prefix: false }, bar: true } } })
     .parse({ line: [] })
@@ -26,7 +28,8 @@ it(`can change prefix for one parameter`, () => {
 it(`can change default prefix and prefix for one parameter`, () => {
   environmentManager.set(`foo`, `foo_env`)
   environmentManager.set(`param_bar`, `bar_env`)
-  const args = Command.parameter(`--foo`, s.default(`default_foo`))
+  const args = Command.create()
+    .parameter(`--foo`, s.default(`default_foo`))
     .parameter(`--bar`, s.default(`default_bar`))
     .settings({
       parameters: {
@@ -43,7 +46,8 @@ it(`can change default prefix and prefix for one parameter`, () => {
 
 describe(`when configuring parameters, environment becomes opt-in`, () => {
   it(`with default not set`, () => {
-    const args = Command.parameter(`--foo`, s.default(`foo`))
+    const args = Command.create()
+      .parameter(`--foo`, s.default(`foo`))
       .parameter(`--bar`, s.default(`bar`))
       .parameter(`--qux`, s.default(`qux`))
       .settings({
@@ -60,7 +64,8 @@ describe(`when configuring parameters, environment becomes opt-in`, () => {
     expect(args).toMatchObject({ foo: `foo_env`, bar: `bar`, qux: `qux` })
   })
   it(`even with default configured`, () => {
-    const args = Command.parameter(`--foo`, s.default(`foo`))
+    const args = Command.create()
+      .parameter(`--foo`, s.default(`foo`))
       .parameter(`--bar`, s.default(`bar`))
       .parameter(`--qux`, s.default(`qux`))
       .settings({
@@ -77,7 +82,8 @@ describe(`when configuring parameters, environment becomes opt-in`, () => {
   describe(` unless...`, () => {
     it(`default is shorthand true`, () => {
       environmentManager.set({ moo_foo: `moo_foo_env`, cli_param_bar: `bar_env`, cli_param_qux: `qux_env` })
-      const args = Command.parameter(`--foo`, s.default(`foo`))
+      const args = Command.create()
+        .parameter(`--foo`, s.default(`foo`))
         .parameter(`--bar`, s.default(`bar`))
         .parameter(`--qux`, s.default(`qux`))
         .settings({ parameters: { environment: { $default: true, foo: { prefix: `MOO` } } } })
@@ -86,7 +92,8 @@ describe(`when configuring parameters, environment becomes opt-in`, () => {
     })
     it(`default is longhand true`, () => {
       environmentManager.set({ moo_foo: `moo_foo_env`, cli_param_bar: `bar_env`, cli_param_qux: `qux_env` })
-      const args = Command.parameter(`--foo`, s.default(`foo`))
+      const args = Command.create()
+        .parameter(`--foo`, s.default(`foo`))
         .parameter(`--bar`, s.default(`bar`))
         .parameter(`--qux`, s.default(`qux`))
         .settings({ parameters: { environment: { $default: { enabled: true }, foo: { prefix: `MOO` } } } })

--- a/packages/@molt/command/tests/environment/types/boolean.spec.ts
+++ b/packages/@molt/command/tests/environment/types/boolean.spec.ts
@@ -10,5 +10,5 @@ test.each([
   [`0`, { foo: false }],
 ])(`%s`, (value, expected) => {
   environmentManager.set(`cli_param_foo`, value)
-  expect(Command.parameter(`foo`, b).parse({ line: [] })).toMatchObject(expected)
+  expect(Command.create().parameter(`foo`, b).parse({ line: [] })).toMatchObject(expected)
 })

--- a/packages/@molt/command/tests/exclusive.spec.ts
+++ b/packages/@molt/command/tests/exclusive.spec.ts
@@ -9,9 +9,9 @@ const settings: Settings.Input = { onError: `throw`, helpOnError: false }
 
 describe(`optional`, () => {
   it(`leads to optional type`, () => {
-    c = Command.parametersExclusive(`method`, ($$) =>
-      $$.parameter(`v version`, s).parameter(`b bump`, e).optional(),
-    ).parse({ line: [`-v`, `1.0.0`] })
+    c = Command.create()
+      .parametersExclusive(`method`, ($$) => $$.parameter(`v version`, s).parameter(`b bump`, e).optional())
+      .parse({ line: [`-v`, `1.0.0`] })
 
     expectType<typeof c>(
       as<{
@@ -29,43 +29,43 @@ describe(`optional`, () => {
   })
 
   it(`can accept line arg`, () => {
-    c = Command.parametersExclusive(`method`, ($$) =>
-      $$.parameter(`v version`, s).parameter(`b bump`, e).optional(),
-    ).parse({ line: [`-v`, `1.0.0`] })
+    c = Command.create()
+      .parametersExclusive(`method`, ($$) => $$.parameter(`v version`, s).parameter(`b bump`, e).optional())
+      .parse({ line: [`-v`, `1.0.0`] })
     expect(c).toMatchObject({ method: { _tag: `version`, value: `1.0.0` } })
   })
 
   it(`can accept env arg`, () => {
-    c = Command.parametersExclusive(`method`, ($$) =>
-      $$.parameter(`v version`, s).parameter(`b bump`, e).optional(),
-    ).parse({ environment: { cli_param_v: `1.0.0` } })
+    c = Command.create()
+      .parametersExclusive(`method`, ($$) => $$.parameter(`v version`, s).parameter(`b bump`, e).optional())
+      .parse({ environment: { cli_param_v: `1.0.0` } })
     expect(c).toMatchObject({ method: { _tag: `version`, value: `1.0.0` } })
   })
   it(`can accept nothing`, () => {
-    c = Command.parametersExclusive(`method`, ($$) =>
-      $$.parameter(`v version`, s).parameter(`b bump`, e).optional(),
-    ).parse()
+    c = Command.create()
+      .parametersExclusive(`method`, ($$) => $$.parameter(`v version`, s).parameter(`b bump`, e).optional())
+      .parse()
     expect(`method` in c).toBe(false)
   })
   it(`if two args then error`, () => {
-    const c = Command.parametersExclusive(`method`, ($$) =>
-      $$.parameter(`v version`, s).parameter(`b bump`, e).optional(),
-    ).settings(settings)
+    const c = Command.create()
+      .parametersExclusive(`method`, ($$) => $$.parameter(`v version`, s).parameter(`b bump`, e).optional())
+      .settings(settings)
     expect(() => c.parse({ line: [`-v`, `1.0.0`, `-b`, `major`] })).toThrowErrorMatchingSnapshot()
   })
 })
 
 describe(`required`, () => {
   it(`if no arg given then error`, () => {
-    const c = Command.parametersExclusive(`method`, ($$) =>
-      $$.parameter(`v version`, s).parameter(`b bump`, e),
-    ).settings(settings)
+    const c = Command.create()
+      .parametersExclusive(`method`, ($$) => $$.parameter(`v version`, s).parameter(`b bump`, e))
+      .settings(settings)
     expect(c.parse).toThrowErrorMatchingSnapshot()
   })
   it(`if two args then error`, () => {
-    const c = Command.parametersExclusive(`method`, ($$) =>
-      $$.parameter(`v version`, s).parameter(`b bump`, e),
-    ).settings(settings)
+    const c = Command.create()
+      .parametersExclusive(`method`, ($$) => $$.parameter(`v version`, s).parameter(`b bump`, e))
+      .settings(settings)
     expect(() => c.parse({ line: [`-v`, `1.0.0`, `-b`, `major`] })).toThrowErrorMatchingSnapshot()
   })
 })
@@ -73,7 +73,7 @@ describe(`required`, () => {
 describe(`default`, () => {
   it(`method params are based on group params defined above`, () => {
     // prettier-ignore
-    Command.parametersExclusive(`method`, ($$) => {
+    Command.create().parametersExclusive(`method`, ($$) => {
       const c = $$.parameter(`v version`, s).parameter(`b bump`, e)
       const m1 = c.default 
       expectType<Parameters<typeof m1>>(as<[tag: 'version' | 'bump', value: 'any string']>())
@@ -85,9 +85,10 @@ describe(`default`, () => {
     })
   })
   it(`leads to non-optional type`, () => {
-    const a = Command.parametersExclusive(`method`, ($$) =>
-      $$.parameter(`v version`, s).parameter(`b bump`, e).default(`bump`, `major`),
-    )
+    const a = Command.create()
+      .parametersExclusive(`method`, ($$) =>
+        $$.parameter(`v version`, s).parameter(`b bump`, e).default(`bump`, `major`),
+      )
       .settings(settings)
       .parse()
     expectType<typeof a>(
@@ -105,9 +106,10 @@ describe(`default`, () => {
     )
   })
   it(`used if nothing passed for group`, () => {
-    const a = Command.parametersExclusive(`method`, ($$) =>
-      $$.parameter(`v version`, s).parameter(`b bump`, e).default(`bump`, `patch`),
-    )
+    const a = Command.create()
+      .parametersExclusive(`method`, ($$) =>
+        $$.parameter(`v version`, s).parameter(`b bump`, e).default(`bump`, `patch`),
+      )
       .settings(settings)
       .parse()
     expect(a.method).toMatchObject({ _tag: `bump`, value: `patch` })

--- a/packages/@molt/command/tests/help/help.spec.ts
+++ b/packages/@molt/command/tests/help/help.spec.ts
@@ -7,24 +7,30 @@ const processExit = mockProcessExit()
 const processStdout = mockProcessStdout()
 
 test(`exits 0`, () => {
-  Command.parameter(`a`, s.optional()).parse({ line: [`-h`] })
+  Command.create()
+    .parameter(`a`, s.optional())
+    .parse({ line: [`-h`] })
   expect(processExit.mock.lastCall?.[0]).toBe(0)
 })
 
 test(`can be triggered by -h`, () => {
-  Command.parameter(`a`, s.optional()).parse({ line: [`-h`] })
+  Command.create()
+    .parameter(`a`, s.optional())
+    .parse({ line: [`-h`] })
   expect(processExit.mock.lastCall?.[0]).toBe(0)
   expect(processStdout.mock.calls[0]).toMatch(/parameters/i)
 })
 
 test(`can be triggered by --help`, () => {
-  Command.parameter(`a`, s.optional()).parse({ line: [`-h`] })
+  Command.create()
+    .parameter(`a`, s.optional())
+    .parse({ line: [`-h`] })
   expect(processExit.mock.lastCall?.[0]).toBe(0)
   expect(processStdout.mock.calls[0]).toMatch(/parameters/i)
 })
 
 test(`can be triggered by passing no arguments`, () => {
-  Command.parameter(`a`, s.optional()).parse({ line: [] })
+  Command.create().parameter(`a`, s.optional()).parse({ line: [] })
   expect(processExit.mock.lastCall?.[0]).toBe(0)
   expect(processStdout.mock.calls[0]).toMatch(/parameters/i)
 })

--- a/packages/@molt/command/tests/help/rendering.spec.ts
+++ b/packages/@molt/command/tests/help/rendering.spec.ts
@@ -33,11 +33,12 @@ $.only = (description: string, builder: RootBuilder<any>) => {
 
 $(
   `if command has description it is shown`,
-  Command.description(`Blah blah blah`).parameter(`foo`, s.optional()),
+  Command.create().description(`Blah blah blah`).parameter(`foo`, s.optional()),
 )
 
 it(`if there is optional param it is shown`, () => {
-  Command.parameter(`a`, s.optional())
+  Command.create()
+    .parameter(`a`, s.optional())
     .settings({ onOutput })
     .parse({ line: [`-h`] })
   expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -45,7 +46,8 @@ it(`if there is optional param it is shown`, () => {
 })
 
 it(`if parameter has description it is shown`, () => {
-  Command.parameter(`a`, s.optional().describe(`Blah blah blah.`))
+  Command.create()
+    .parameter(`a`, s.optional().describe(`Blah blah blah.`))
     .settings({ onOutput })
     .parse({ line: [`-h`] })
   expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -53,7 +55,8 @@ it(`if parameter has description it is shown`, () => {
 })
 
 it(`long description wraps within column`, () => {
-  Command.parameter(`a`, s.optional().describe(`Blah blah blah. Blah blah blah. Blah blah blah.`))
+  Command.create()
+    .parameter(`a`, s.optional().describe(`Blah blah blah. Blah blah blah. Blah blah blah.`))
     .settings({ onOutput })
     .parse({ line: [`-h`] })
   expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -61,7 +64,8 @@ it(`long description wraps within column`, () => {
 })
 
 it(`if parameter has default it is shown`, () => {
-  Command.parameter(`foo`, s.default(`bar`))
+  Command.create()
+    .parameter(`foo`, s.default(`bar`))
     .settings({ onOutput })
     .parse({ line: [`-h`] })
   expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -69,7 +73,8 @@ it(`if parameter has default it is shown`, () => {
 })
 
 it(`if parameter is optional without default then its default shows up as "undefined"`, () => {
-  Command.parameter(`foo`, s.optional())
+  Command.create()
+    .parameter(`foo`, s.optional())
     .settings({ onOutput })
     .parse({ line: [`-h`] })
   expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -77,12 +82,13 @@ it(`if parameter is optional without default then its default shows up as "undef
 })
 
 it(`if there is an error trying to get default then a nice message is shown`, () => {
-  Command.parameter(
-    `foo`,
-    s.default(() => {
-      throw new Error(`whoops`)
-    }),
-  )
+  Command.create()
+    .parameter(
+      `foo`,
+      s.default(() => {
+        throw new Error(`whoops`)
+      }),
+    )
     .settings({ onOutput })
     .parse({ line: [`-h`] })
   expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -90,12 +96,13 @@ it(`if there is an error trying to get default then a nice message is shown`, ()
 })
 
 it(`if there is an error trying to get default then a nice message is shown`, () => {
-  Command.parameter(
-    `foo`,
-    s.default(() => {
-      throw new Error(`whoops`)
-    }),
-  )
+  Command.create()
+    .parameter(
+      `foo`,
+      s.default(() => {
+        throw new Error(`whoops`)
+      }),
+    )
     .settings({ onOutput })
     .parse({ line: [`-h`] })
   expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -104,7 +111,7 @@ it(`if there is an error trying to get default then a nice message is shown`, ()
 
 it(`enums do not mess up alignment when they are widest line in the column`, () => {
   // prettier-ignore
-  Command.parameter(
+  Command.create().parameter(
     `foo`, z.enum([`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`]),).parameter(
     `bar`, s.optional(),
   ).settings({onOutput}).parse({line:[`-h`]})
@@ -114,7 +121,8 @@ it(`enums do not mess up alignment when they are widest line in the column`, () 
 
 describe(`enum`, () => {
   it(`enum members are listed`, () => {
-    Command.parameter(`foo`, z.enum([`apple`, `dolphin`, `cab`]))
+    Command.create()
+      .parameter(`foo`, z.enum([`apple`, `dolphin`, `cab`]))
       .settings({ onOutput })
       .parse({ line: [`-h`] })
     expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -122,7 +130,8 @@ describe(`enum`, () => {
   })
 
   it(`optional enum members are listed`, () => {
-    Command.parameter(`foo`, z.enum([`apple`, `dolphin`, `cab`]).optional())
+    Command.create()
+      .parameter(`foo`, z.enum([`apple`, `dolphin`, `cab`]).optional())
       .settings({ onOutput })
       .parse({ line: [`-h`] })
     expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -130,7 +139,8 @@ describe(`enum`, () => {
   })
 
   it(`when there is only one enum member it is prefixed with "enum:" to avoid confusion of it looking like the name of a kind of type`, () => {
-    Command.parameter(`foo`, z.enum([`apple`]))
+    Command.create()
+      .parameter(`foo`, z.enum([`apple`]))
       .settings({ onOutput })
       .parse({ line: [`-h`] })
     expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -138,22 +148,23 @@ describe(`enum`, () => {
   })
 
   it(`when there are many members they wrap`, () => {
-    Command.parameter(
-      `foo`,
-      z.enum([
-        `apple`,
-        `baby`,
-        `cannabis`,
-        `dinosaur`,
-        `elephant`,
-        `fanna`,
-        `goat`,
-        `house`,
-        `island`,
-        `jake`,
-        `kilomanjara`,
-      ]),
-    )
+    Command.create()
+      .parameter(
+        `foo`,
+        z.enum([
+          `apple`,
+          `baby`,
+          `cannabis`,
+          `dinosaur`,
+          `elephant`,
+          `fanna`,
+          `goat`,
+          `house`,
+          `island`,
+          `jake`,
+          `kilomanjara`,
+        ]),
+      )
       .settings({ onOutput })
       .parse({ line: [`-h`] })
     expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
@@ -163,21 +174,24 @@ describe(`enum`, () => {
 
 describe(`environment`, () => {
   it(`when environment is disabled then environment doc is not shown`, () => {
-    Command.parameter(`foo`, s)
+    Command.create()
+      .parameter(`foo`, s)
       .settings({ onOutput, parameters: { environment: false } })
       .parse({ line: [`-h`] })
     expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
     expect(output.value).toMatchSnapshot(`polychrome`)
   })
   it(`when environment is enabled it shows as the last column`, () => {
-    Command.parameter(`foo`, s)
+    Command.create()
+      .parameter(`foo`, s)
       .settings({ onOutput, parameters: { environment: true } })
       .parse({ line: [`-h`] })
     expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
     expect(output.value).toMatchSnapshot(`polychrome`)
   })
   it(`when environment is disabled for one parameter it has X indicating that`, () => {
-    Command.parameter(`foo`, s)
+    Command.create()
+      .parameter(`foo`, s)
       .parameter(`bar`, s)
       .settings({ onOutput, parameters: { environment: { $default: true, foo: false } } })
       .parse({ line: [`-h`] })
@@ -185,7 +199,8 @@ describe(`environment`, () => {
     expect(output.value).toMatchSnapshot(`polychrome`)
   })
   it(`when environment has custom prefix it is displayed`, () => {
-    Command.parameter(`foo`, s)
+    Command.create()
+      .parameter(`foo`, s)
       .parameter(`bar`, s)
       .settings({ onOutput, parameters: { environment: { $default: true, foo: { prefix: `moo` } } } })
       .parse({ line: [`-h`] })
@@ -193,7 +208,8 @@ describe(`environment`, () => {
     expect(output.value).toMatchSnapshot(`polychrome`)
   })
   it(`when environment has multiple custom prefix they are displayed`, () => {
-    Command.parameter(`foo`, s)
+    Command.create()
+      .parameter(`foo`, s)
       .parameter(`bar`, s)
       .settings({
         onOutput,
@@ -204,7 +220,8 @@ describe(`environment`, () => {
     expect(output.value).toMatchSnapshot(`polychrome`)
   })
   it(`when environment has no prefix it is displayed`, () => {
-    Command.parameter(`foo`, s)
+    Command.create()
+      .parameter(`foo`, s)
       .parameter(`bar`, s)
       .settings({ onOutput, parameters: { environment: { $default: true, foo: { prefix: false } } } })
       .parse({ line: [`-h`] })
@@ -216,7 +233,8 @@ describe(`environment`, () => {
 describe(`exclusive`, () => {
   describe(`optional`, () => {
     it(`shows exclusive parameters as a group`, () => {
-      Command.parametersExclusive(`foo`, (_) => _.parameter(`b bar`, s).parameter(`z baz`, s).optional())
+      Command.create()
+        .parametersExclusive(`foo`, (_) => _.parameter(`b bar`, s).parameter(`z baz`, s).optional())
         .settings({ onOutput })
         .parse({
           line: [`-h`],
@@ -227,9 +245,10 @@ describe(`exclusive`, () => {
   })
   describe(`default`, () => {
     it(`shows the group default`, () => {
-      Command.parametersExclusive(`foo`, (_) =>
-        _.parameter(`b bar`, s).parameter(`z baz`, s).default(`bar`, `bar_default`),
-      )
+      Command.create()
+        .parametersExclusive(`foo`, (_) =>
+          _.parameter(`b bar`, s).parameter(`z baz`, s).default(`bar`, `bar_default`),
+        )
         .settings({ onOutput })
         .parse({
           line: [`-h`],
@@ -240,9 +259,10 @@ describe(`exclusive`, () => {
   })
   describe(`default with long value`, () => {
     it(`shows the group default`, () => {
-      Command.parametersExclusive(`foo`, (_) =>
-        _.parameter(`b bar`, s).parameter(`z baz`, s).default(`bar`, `bar_defaulttttttttttttttttttttt`),
-      )
+      Command.create()
+        .parametersExclusive(`foo`, (_) =>
+          _.parameter(`b bar`, s).parameter(`z baz`, s).default(`bar`, `bar_defaulttttttttttttttttttttt`),
+        )
         .settings({ onOutput })
         .parse({
           line: [`-h`],
@@ -253,9 +273,10 @@ describe(`exclusive`, () => {
   })
   describe(`with environment disabled`, () => {
     it(`shows the group default`, () => {
-      Command.parametersExclusive(`foo`, (_) =>
-        _.parameter(`b bar`, s).parameter(`z baz`, s).default(`bar`, `bar_default`),
-      )
+      Command.create()
+        .parametersExclusive(`foo`, (_) =>
+          _.parameter(`b bar`, s).parameter(`z baz`, s).default(`bar`, `bar_default`),
+        )
         .settings({ onOutput, parameters: { environment: false } })
         .parse({
           line: [`-h`],
@@ -269,7 +290,8 @@ describe(`exclusive`, () => {
 describe(`union parameter`, () => {
   describe(`condensed pipe style`, () => {
     it(`used when no descriptions given for anything`, () => {
-      Command.parameter(`b bar`, z.union([z.string(), z.number()]))
+      Command.create()
+        .parameter(`b bar`, z.union([z.string(), z.number()]))
         .settings({ onOutput })
         .parse({
           line: [`-h`],
@@ -278,7 +300,8 @@ describe(`union parameter`, () => {
       expect(output.value).toMatchSnapshot(`polychrome`)
     })
     it(`used when only overall description given`, () => {
-      Command.parameter(`b bar`, z.union([z.string(), z.number()]).describe(`Blah blah blah.`))
+      Command.create()
+        .parameter(`b bar`, z.union([z.string(), z.number()]).describe(`Blah blah blah.`))
         .settings({ onOutput })
         .parse({
           line: [`-h`],
@@ -289,20 +312,22 @@ describe(`union parameter`, () => {
   })
   describe(`expanded style`, () => {
     it(`can be forced via settings`, () => {
-      Command.parameter(`b bar`, z.union([z.string(), z.number()]))
+      Command.create()
+        .parameter(`b bar`, z.union([z.string(), z.number()]))
         .settings({ onOutput, helpRendering: { union: { mode: `expandAlways` } } })
         .parse({ line: [`-h`] })
       expect(stripAnsi(output.value)).toMatchSnapshot(`monochrome`)
       expect(output.value).toMatchSnapshot(`polychrome`)
     })
     it(`shows member on each line if each has description`, () => {
-      Command.parameter(
-        `b bar`,
-        z.union([
-          z.string().describe(`Blah blah blah string.`),
-          z.number().describe(`Blah blah blah number.`),
-        ]),
-      )
+      Command.create()
+        .parameter(
+          `b bar`,
+          z.union([
+            z.string().describe(`Blah blah blah string.`),
+            z.number().describe(`Blah blah blah number.`),
+          ]),
+        )
         .settings({ onOutput })
         .parse({
           line: [`-h`],
@@ -311,7 +336,8 @@ describe(`union parameter`, () => {
       expect(output.value).toMatchSnapshot(`polychrome`)
     })
     it(`shows member on each line if at least one has description`, () => {
-      Command.parameter(`b bar`, z.union([z.string(), z.number().describe(`Blah blah blah number.`)]))
+      Command.create()
+        .parameter(`b bar`, z.union([z.string(), z.number().describe(`Blah blah blah number.`)]))
         .settings({ onOutput })
         .parse({
           line: [`-h`],
@@ -320,15 +346,16 @@ describe(`union parameter`, () => {
       expect(output.value).toMatchSnapshot(`polychrome`)
     })
     it(`shows overall description above all members when members also have descriptions`, () => {
-      Command.parameter(
-        `b bar`,
-        z
-          .union([
-            z.string().describe(`Blah blah blah string.`),
-            z.number().describe(`Blah blah blah number.`),
-          ])
-          .describe(`Blah blah blah overall.`),
-      )
+      Command.create()
+        .parameter(
+          `b bar`,
+          z
+            .union([
+              z.string().describe(`Blah blah blah string.`),
+              z.number().describe(`Blah blah blah number.`),
+            ])
+            .describe(`Blah blah blah overall.`),
+        )
         .settings({ onOutput })
         .parse({
           line: [`-h`],
@@ -338,13 +365,17 @@ describe(`union parameter`, () => {
     })
   })
   it(`shows default when overall has a default`, () => {
-    Command.parameter(
-      `b bar`,
-      z
-        .union([z.string().describe(`Blah blah blah string.`), z.number().describe(`Blah blah blah number.`)])
-        .default(1)
-        .describe(`Blah blah blah overall.`),
-    )
+    Command.create()
+      .parameter(
+        `b bar`,
+        z
+          .union([
+            z.string().describe(`Blah blah blah string.`),
+            z.number().describe(`Blah blah blah number.`),
+          ])
+          .default(1)
+          .describe(`Blah blah blah overall.`),
+      )
       .settings({ onOutput })
       .parse({
         line: [`-h`],
@@ -353,13 +384,17 @@ describe(`union parameter`, () => {
     expect(output.value).toMatchSnapshot(`polychrome`)
   })
   it(`shows default as undefined when overall optional`, () => {
-    Command.parameter(
-      `b bar`,
-      z
-        .union([z.string().describe(`Blah blah blah string.`), z.number().describe(`Blah blah blah number.`)])
-        .optional()
-        .describe(`Blah blah blah overall.`),
-    )
+    Command.create()
+      .parameter(
+        `b bar`,
+        z
+          .union([
+            z.string().describe(`Blah blah blah string.`),
+            z.number().describe(`Blah blah blah number.`),
+          ])
+          .optional()
+          .describe(`Blah blah blah overall.`),
+      )
       .settings({ onOutput })
       .parse({
         line: [`-h`],

--- a/packages/@molt/command/tests/line/builder.spec.ts
+++ b/packages/@molt/command/tests/line/builder.spec.ts
@@ -4,14 +4,15 @@ import { describe, expect, it } from 'vitest'
 
 describe(`.create`, () => {
   it(`creates a parameters definition`, () => {
-    const def = Command.parameter(`x`, s)
+    const def = Command.create().parameter(`x`, s)
     expect(def.parse).toBeTypeOf(`function`)
   })
 })
 
 describe(`settings`, () => {
   it(`permits setting a description`, () => {
-    Command.parameter(`x`, s)
+    Command.create()
+      .parameter(`x`, s)
       .settings({ description: `foobar` })
       .parse({ line: [`-x`, `foobar`] })
   })

--- a/packages/@molt/command/tests/line/name.spec.ts
+++ b/packages/@molt/command/tests/line/name.spec.ts
@@ -20,7 +20,7 @@ describe(`string`, () => {
 		[`-v --ver`,        [`-v`, `foo`], 							{ ver: `foo` }],
 		[`-v`,              [`-v`, `foo`], 							{ v:   `foo` }],
 	])(`spec %s + input %s = internal %s`, (spec, input, expectedArgs) => {
-		const args = Command.parameter(spec as any, s).parse({line:input})
+		const args = Command.create().parameter(spec as any, s).parse({line:input})
 		expect(args).toMatchObject(expectedArgs)
 	})
 })
@@ -40,7 +40,7 @@ describe(`boolean`, () => {
 		[`-v --ver`,        [`-v`], 							{ ver: true }],
 		[`-v`,              [`-v`], 							{ v:   true }],
 	])(`spec %s + input %s = internal %s`, (spec, input, expectedArgs) => {
-		const args = Command.parameter(spec as any, b).parse({line:input})
+		const args = Command.create().parameter(spec as any, b).parse({line:input})
 		expect(args).toMatchObject(expectedArgs)
 	})
 })
@@ -51,7 +51,8 @@ describe(`stacked short flags`, () => {
     [[`-ac`], { a: true, b: false, c: true }],
     [[`-abcd`, `foo`], { a: true, b: true, c: true, d: `foo` }],
   ])(`stacked short flag input of %s becomes %s`, (input, expectedArgs) => {
-    const args = Command.parameter(`a`, b.default(false))
+    const args = Command.create()
+      .parameter(`a`, b.default(false))
       .parameter(`b`, b.default(false))
       .parameter(`c`, b.default(false))
       .parameter(`d`, s.optional())
@@ -67,7 +68,7 @@ describe(`separator`, () => {
     [[`--foo= `, `bar`], { foo: `bar` }],
     [[`--foo`, `=bar`], { foo: `=bar` }],
   ])(`spec %s becomes %s`, (input, expectedArgs) => {
-    const args = Command.parameter(`foo`, s).parse({ line: input })
+    const args = Command.create().parameter(`foo`, s).parse({ line: input })
     expect(args).toMatchObject(expectedArgs)
   })
 })
@@ -81,7 +82,7 @@ describe(`case`, () => {
       [`--fooBar`,  [`--fooBar`, `foo`], { fooBar: `foo` }],
       [`--fooBar`,  [`--foo-bar`, `foo`], { fooBar: `foo` }],
     ])(`spec %s + input %s = internal %s`, (spec, input, expectedArgs) => {
-      const args = Command.parameter(spec as any, s).parse({line:input})
+      const args = Command.create().parameter(spec as any, s).parse({line:input})
       expect(args).toMatchObject(expectedArgs)
     })
   })
@@ -98,25 +99,33 @@ describe(`case`, () => {
       [`--fooBar`,  [`--noFooBar`],     { fooBar: false }],
       [`--fooBar`,  [`--no-foo-bar`],   { fooBar: false }],
     ])(`spec %s + input %s = internal %s`, (spec, input, expectedArgs) => {
-      const args = Command.parameter(spec as any, b).parse({line:input})
+      const args = Command.create().parameter(spec as any, b).parse({line:input})
       expect(args).toMatchObject(expectedArgs)
     })
   })
 
   test(`kebab case param spec can be passed camel case parameter`, () => {
-    const args = Command.parameter(`--foo-bar`, s).parse({ line: [`--fooBar`, `foo`] })
+    const args = Command.create()
+      .parameter(`--foo-bar`, s)
+      .parse({ line: [`--fooBar`, `foo`] })
     assert<IsExact<{ fooBar: string }, typeof args>>(true)
   })
   test(`kebab case param spec can be passed kebab case parameter`, () => {
-    const args = Command.parameter(`--foo-bar`, s).parse({ line: [`--foo-bar`, `foo`] })
+    const args = Command.create()
+      .parameter(`--foo-bar`, s)
+      .parse({ line: [`--foo-bar`, `foo`] })
     assert<IsExact<{ fooBar: string }, typeof args>>(true)
   })
   test(`camel case param spec can be passed kebab case parameter`, () => {
-    const args = Command.parameter(`--fooBar`, s).parse({ line: [`--foo-bar`, `foo`] })
+    const args = Command.create()
+      .parameter(`--fooBar`, s)
+      .parse({ line: [`--foo-bar`, `foo`] })
     assert<IsExact<{ fooBar: string }, typeof args>>(true)
   })
   test(`camel case param spec can be passed camel case parameter`, () => {
-    const args = Command.parameter(`--fooBar`, s).parse({ line: [`--fooBar`, `foo`] })
+    const args = Command.create()
+      .parameter(`--fooBar`, s)
+      .parse({ line: [`--fooBar`, `foo`] })
     assert<IsExact<{ fooBar: string }, typeof args>>(true)
   })
 })

--- a/packages/@molt/command/tests/line/types/boolean.spec.ts
+++ b/packages/@molt/command/tests/line/types/boolean.spec.ts
@@ -5,26 +5,32 @@ import { assert } from 'conditional-type-checks'
 import { describe, expect, it } from 'vitest'
 
 it(`implies true`, () => {
-  const args = Command.parameter(`--verbose`, b).parse({ line: [`--verbose`] })
+  const args = Command.create()
+    .parameter(`--verbose`, b)
+    .parse({ line: [`--verbose`] })
   assert<IsExact<{ verbose: boolean }, typeof args>>(true)
   expect(args).toMatchObject({ verbose: true })
 })
 it(`has a negated variant that implies false`, () => {
-  const args = Command.parameter(`--verbose`, b).parse({ line: [`--no-verbose`] })
+  const args = Command.create()
+    .parameter(`--verbose`, b)
+    .parse({ line: [`--no-verbose`] })
   assert<IsExact<{ verbose: boolean }, typeof args>>(true)
   expect(args).toMatchObject({ verbose: false })
 })
 
 describe(`when a parameter default is specified`, () => {
   it(`uses the default value when no input given`, () => {
-    const args = Command.parameter(`--verbose`, b.default(false)).parse({ line: [] })
+    const args = Command.create().parameter(`--verbose`, b.default(false)).parse({ line: [] })
     assert<IsExact<{ verbose: boolean }, typeof args>>(true)
     expect(args).toMatchObject({ verbose: false })
   })
   it(`accepts the negated parameter`, () => {
-    const args = Command.parameter(`--verbose`, b.default(true)).parse({
-      line: [`--no-verbose`],
-    })
+    const args = Command.create()
+      .parameter(`--verbose`, b.default(true))
+      .parse({
+        line: [`--no-verbose`],
+      })
     assert<IsExact<{ verbose: boolean }, typeof args>>(true)
     expect(args).toMatchObject({ verbose: false })
   })
@@ -32,14 +38,17 @@ describe(`when a parameter default is specified`, () => {
 
 describe(`when parameter is optional`, () => {
   it(`allows no input to be given, resulting in omitted key`, () => {
-    const args = Command.parameter(`--verbose`, b.optional())
+    const args = Command.create()
+      .parameter(`--verbose`, b.optional())
       .settings({ helpOnNoArguments: false })
       .parse({ line: [] })
     assert<IsExact<{ verbose: boolean | undefined }, typeof args>>(true)
     expect(Object.keys(args)).not.toContain(`verbose`)
   })
   it(`input can be given`, () => {
-    const args = Command.parameter(`--verbose`, b.optional()).parse({ line: [`--verbose`] })
+    const args = Command.create()
+      .parameter(`--verbose`, b.optional())
+      .parse({ line: [`--verbose`] })
     assert<IsExact<{ verbose: boolean | undefined }, typeof args>>(true)
     expect(args).toMatchObject({ verbose: true })
   })

--- a/packages/@molt/command/tests/line/types/enum.spec.ts
+++ b/packages/@molt/command/tests/line/types/enum.spec.ts
@@ -6,19 +6,23 @@ import { z } from 'zod'
 
 describe(`errors`, () => {
   it(`when argument missing (last position)`, () => {
-    Command.parameter(`--mode`, z.enum([`a`, `b`])).parse({ line: [`--mode`] })
+    Command.create()
+      .parameter(`--mode`, z.enum([`a`, `b`]))
+      .parse({ line: [`--mode`] })
     expect(stdout.mock.calls).toMatchSnapshot()
   })
   it(`when argument missing (non-last position)`, () => {
     // prettier-ignore
-    Command.parameter( `--name`, s).parameter( `--mode`, z.enum([`a`,`b`]) ).parse({line:[` --mode`, `--name`, `joe`]})
+    Command.create().parameter( `--name`, s).parameter( `--mode`, z.enum([`a`,`b`]) ).parse({line:[` --mode`, `--name`, `joe`]})
     expect(stdout.mock.calls).toMatchSnapshot()
   })
   it(`is validated`, () => {
     // const args = Parameters.create({ '--mode': z.enum([`a`, `b`, `c`]) }).parse({line:[`--mode`, `bad`]})
     // assert<IsExact<{ mode: 'a'|'b'|'c' }, typeof args>>(true)
     // expect(args).toMatchObject({ mode: true })
-    Command.parameter(`--mode`, z.enum([`a`, `b`, `c`])).parse({ line: [`--mode`, `bad`] })
+    Command.create()
+      .parameter(`--mode`, z.enum([`a`, `b`, `c`]))
+      .parse({ line: [`--mode`, `bad`] })
     expect(stdout.mock.calls).toMatchSnapshot()
   })
 })

--- a/packages/@molt/command/tests/line/types/number.spec.ts
+++ b/packages/@molt/command/tests/line/types/number.spec.ts
@@ -7,22 +7,29 @@ import { assert } from 'conditional-type-checks'
 import { describe, expect, it } from 'vitest'
 
 it(`casts the input as a number`, () => {
-  const args = Command.parameter(`--age`, n).parse({ line: [`--age`, `1`] })
+  const args = Command.create()
+    .parameter(`--age`, n)
+    .parse({ line: [`--age`, `1`] })
   assert<IsExact<{ age: number }, typeof args>>(true)
   expect(args).toMatchObject({ age: 1 })
 })
 
 describe(`errors`, () => {
   it(`validates the  input`, () => {
-    Command.parameter(`--age`, n.int()).parse({ line: [`--age`, `1.1`] })
+    Command.create()
+      .parameter(`--age`, n.int())
+      .parse({ line: [`--age`, `1.1`] })
     expect(stdout.mock.calls).toMatchSnapshot()
   })
   it(`throws error when argument missing (last position)`, () => {
-    Command.parameter(`--age`, n).parse({ line: [`--age`] })
+    Command.create()
+      .parameter(`--age`, n)
+      .parse({ line: [`--age`] })
     expect(stdout.mock.calls).toMatchSnapshot()
   })
   it(`throws error when argument missing (non-last position)`, () => {
-    Command.parameter(`--name`, s)
+    Command.create()
+      .parameter(`--name`, s)
       .parameter(`--age`, n)
       .parse({
         line: [` --age`, `--name`, `joe`],

--- a/packages/@molt/command/tests/line/types/string.spec.ts
+++ b/packages/@molt/command/tests/line/types/string.spec.ts
@@ -15,13 +15,8 @@ describe(`errors`, () => {
     ],
   )(`%s`, (_, parameters, input) => {
     expect(() => {
-      // eslint-disable-next-line
       Object.entries(parameters)
-        // @ts-expect-error todo
-        .reduce((chain, data) => {
-          return chain.parameter(data[0] as any, data[1])
-        }, Command)
-        // @ts-expect-error todo
+        .reduce((chain, data) => chain.parameter(data[0] as any, data[1]), Command.create())
         .settings({ onError: `throw`, helpOnError: false })
         .parse(input)
     }).toThrowErrorMatchingSnapshot()
@@ -30,17 +25,23 @@ describe(`errors`, () => {
 
 describe(`optional`, () => {
   it(`specified input can be omitted, missing key is possible`, () => {
-    const args = Command.parameter(`--foo`, s.optional()).parse({ line: [] })
+    const args = Command.create().parameter(`--foo`, s.optional()).parse({ line: [] })
     assert<IsExact<{ foo: string | undefined }, typeof args>>(true)
     expect(Object.keys(args)).not.toContain(`foo`)
   })
   it(`input can be given`, () => {
-    const args = Command.parameter(`--foo`, s.optional()).parse({ line: [`--foo`, `bar`] })
+    const args = Command.create()
+      .parameter(`--foo`, s.optional())
+      .parse({ line: [`--foo`, `bar`] })
     assert<IsExact<{ foo: string | undefined }, typeof args>>(true)
     expect(args).toMatchObject({ foo: `bar` })
   })
 })
 
 it(`is not trimmed by default`, () => {
-  expect(Command.parameter(`name`, s).parse({ line: [`--name`, `foobar  `] })).toMatchSnapshot()
+  expect(
+    Command.create()
+      .parameter(`name`, s)
+      .parse({ line: [`--name`, `foobar  `] }),
+  ).toMatchSnapshot()
 })

--- a/packages/@molt/command/tests/line/types/zod/number.spec.ts
+++ b/packages/@molt/command/tests/line/types/zod/number.spec.ts
@@ -17,13 +17,10 @@ describe(`zod`, () => {
       ],
     )(`%s`, (_, parameters, input) => {
       expect(() => {
-        // eslint-disable-next-line
         Object.entries(parameters)
-          // @ts-expect-error todo
           .reduce((chain, data) => {
             return chain.parameter(data[0] as any, data[1])
-          }, Command)
-          // @ts-expect-error todo
+          }, Command.create())
           .settings({ onError: `throw`, helpOnError: false })
           .parse(input)
       }).toThrowErrorMatchingSnapshot()

--- a/packages/@molt/command/tests/line/types/zod/static.spec.ts
+++ b/packages/@molt/command/tests/line/types/zod/static.spec.ts
@@ -3,7 +3,7 @@ import { it } from 'vitest'
 import { z } from 'zod'
 
 it(`static supports zod types`, () => {
-  Command.parameter(`x`, z.literal(1))
-  Command.parameter(`x`, z.literal(`1`))
-  Command.parameter(`x`, z.literal(true))
+  Command.create().parameter(`x`, z.literal(1))
+  Command.create().parameter(`x`, z.literal(`1`))
+  Command.create().parameter(`x`, z.literal(true))
 })

--- a/packages/@molt/command/tests/line/types/zod/string.spec.ts
+++ b/packages/@molt/command/tests/line/types/zod/string.spec.ts
@@ -12,13 +12,8 @@ describe(`zod`, () => {
       ],
     )(`%s`, (_, parameters, input) => {
       expect(
-        // eslint-disable-next-line
         Object.entries(parameters)
-          //@ts-expect-error todo
-          .reduce((chain, data) => {
-            return chain.parameter(data[0] as any, data[1])
-          }, Command)
-          //@ts-expect-error todo
+          .reduce((chain, data) => chain.parameter(data[0] as any, data[1]), Command.create())
           .parse(input),
       ).toMatchSnapshot()
     })
@@ -44,13 +39,8 @@ describe(`zod`, () => {
       ],
     )(`%s`, (_, parameters, input) => {
       expect(() => {
-        // eslint-disable-next-line
         Object.entries(parameters)
-          //@ts-expect-error todo
-          .reduce((chain, data) => {
-            return chain.parameter(data[0] as any, data[1])
-          }, Command)
-          //@ts-expect-error todo
+          .reduce((chain, data) => chain.parameter(data[0] as any, data[1]), Command.create())
           .settings({ onError: `throw`, helpOnError: false })
           .parse(input)
       }).toThrowErrorMatchingSnapshot()

--- a/packages/@molt/command/tests/parameters/configurationObject.spec.ts
+++ b/packages/@molt/command/tests/parameters/configurationObject.spec.ts
@@ -4,16 +4,18 @@ import { expectType } from 'tsd'
 import { expect, it } from 'vitest'
 
 it(`parameter can receive configuration object`, () => {
-  const args = Command.parameter(`a`, { schema: s.optional() }).parse({ line: [] })
+  const args = Command.create().parameter(`a`, { schema: s.optional() }).parse({ line: [] })
   expectType<{ a?: string }>(args)
   expect(args).toMatchObject({})
 })
 
 it(`exclusive parameter builder parameter method can receive configuration object`, () => {
-  const args = Command.parametersExclusive(`foo`, (_) => {
-    const x = _.parameter(`a`, { schema: s }).parameter(`b`, { schema: n })
-    return x
-  }).parse({ line: [`-a`, `abc`] })
+  const args = Command.create()
+    .parametersExclusive(`foo`, (_) => {
+      const x = _.parameter(`a`, { schema: s }).parameter(`b`, { schema: n })
+      return x
+    })
+    .parse({ line: [`-a`, `abc`] })
   expectType<{ foo: { _tag: 'a'; value: string } | { _tag: 'b'; value: number } }>(args)
   expect(args).toMatchObject({ foo: { _tag: `a`, value: `abc` } })
 })

--- a/packages/@molt/command/tests/parameters/description.spec.ts
+++ b/packages/@molt/command/tests/parameters/description.spec.ts
@@ -9,25 +9,33 @@ mockProcessExit()
 
 describe(`placement of describe method in zod method chain does not matter`, () => {
   it(`description can trail optional`, () => {
-    Command.parameter(`a`, s.optional().describe(`Blah blah blah.`)).parse({ line: [`-h`] })
+    Command.create()
+      .parameter(`a`, s.optional().describe(`Blah blah blah.`))
+      .parse({ line: [`-h`] })
     const output = processStdout.mock.lastCall?.[0] as string
     expect(stripAnsi(output)).toMatch(/Blah blah blah./)
   })
 
   it(`description can lead optional`, () => {
-    Command.parameter(`a`, s.describe(`Blah blah blah.`).optional()).parse({ line: [`-h`] })
+    Command.create()
+      .parameter(`a`, s.describe(`Blah blah blah.`).optional())
+      .parse({ line: [`-h`] })
     const output = processStdout.mock.lastCall?.[0] as string
     expect(stripAnsi(output)).toMatch(/Blah blah blah./)
   })
 
   it(`description can trail default`, () => {
-    Command.parameter(`a`, s.default(`x`).describe(`Blah blah blah.`)).parse({ line: [`-h`] })
+    Command.create()
+      .parameter(`a`, s.default(`x`).describe(`Blah blah blah.`))
+      .parse({ line: [`-h`] })
     const output = processStdout.mock.lastCall?.[0] as string
     expect(stripAnsi(output)).toMatch(/Blah blah blah./)
   })
 
   it(`description can lead default`, () => {
-    Command.parameter(`a`, s.describe(`Blah blah blah.`).default(`x`)).parse({ line: [`-h`] })
+    Command.create()
+      .parameter(`a`, s.describe(`Blah blah blah.`).default(`x`))
+      .parse({ line: [`-h`] })
     const output = processStdout.mock.lastCall?.[0] as string
     expect(stripAnsi(output)).toMatch(/Blah blah blah./)
   })
@@ -36,21 +44,21 @@ describe(`placement of describe method in zod method chain does not matter`, () 
 describe(`when there are multiple describe methods in the zod method chain only the last (outer most) one is used`, () => {
   it(`last description instance wins`, () => {
     // prettier-ignore
-    Command.parameter( `a`, s.describe(`Blah blah blah 1.`).describe(`Blah blah blah 2.`) ).parse({ line: [`-h`] })
+    Command.create().parameter( `a`, s.describe(`Blah blah blah 1.`).describe(`Blah blah blah 2.`) ).parse({ line: [`-h`] })
     const output = processStdout.mock.lastCall?.[0] as string
     expect(stripAnsi(output)).toMatch(/Blah blah blah 2./)
   })
 
   it(`last description instance separated by default wins`, () => {
     // prettier-ignore
-    Command.parameter( `a`, s.describe(`Blah blah blah 1.`).default(`x`).describe(`Blah blah blah 2.`) ).parse( { line: [`-h`] })
+    Command.create().parameter( `a`, s.describe(`Blah blah blah 1.`).default(`x`).describe(`Blah blah blah 2.`) ).parse( { line: [`-h`] })
     const output = processStdout.mock.lastCall?.[0] as string
     expect(stripAnsi(output)).toMatch(/Blah blah blah 2./)
   })
 
   // prettier-ignore
   it(`last description instance separated by optional wins`, () => {
-    Command.parameter( `a`, s.describe(`Blah blah blah 1.`).optional().describe(`Blah blah blah 2.`) ).parse({ line: [`-h`], })
+    Command.create().parameter( `a`, s.describe(`Blah blah blah 1.`).optional().describe(`Blah blah blah 2.`) ).parse({ line: [`-h`], })
     const output = processStdout.mock.lastCall?.[0] as string
     expect(stripAnsi(output)).toMatch(/Blah blah blah 2./)
   })

--- a/packages/@molt/command/tests/parameters/unionType.spec.ts
+++ b/packages/@molt/command/tests/parameters/unionType.spec.ts
@@ -4,54 +4,70 @@ import { expect, it } from 'vitest'
 import { z } from 'zod'
 
 it(`arg static type is the union`, () => {
-  const args = Command.parameter(`x`, z.union([z.string(), z.number()])).parse({ line: [`-x`, `1`] })
+  const args = Command.create()
+    .parameter(`x`, z.union([z.string(), z.number()]))
+    .parse({ line: [`-x`, `1`] })
   expectType<string | number>(args.x)
 })
 
 it(`spec of number|string parses arg as number if number given`, () => {
-  const args = Command.parameter(`x`, z.union([z.string(), z.number()])).parse({ line: [`-x`, `1`] })
+  const args = Command.create()
+    .parameter(`x`, z.union([z.string(), z.number()]))
+    .parse({ line: [`-x`, `1`] })
   expect(typeof args.x).toBe(`number`)
   expect(args.x).toBe(1)
 })
 
 it(`spec of number|string parses arg as string if non-number given`, () => {
-  const args = Command.parameter(`x`, z.union([z.string(), z.number()])).parse({ line: [`-x`, `1a`] })
+  const args = Command.create()
+    .parameter(`x`, z.union([z.string(), z.number()]))
+    .parse({ line: [`-x`, `1a`] })
   expect(typeof args.x).toBe(`string`)
   expect(args.x).toBe(`1a`)
 })
 
 it(`spec of number|boolean parses arg as boolean true if bool flag given`, () => {
-  const args = Command.parameter(`x`, z.union([z.boolean(), z.number()])).parse({ line: [`-x`] })
+  const args = Command.create()
+    .parameter(`x`, z.union([z.boolean(), z.number()]))
+    .parse({ line: [`-x`] })
   expect(typeof args.x).toBe(`boolean`)
   expect(args.x).toBe(true)
 })
 
 it(`spec of number|boolean parses arg as boolean false if negated bool flag given`, () => {
-  const args = Command.parameter(`xee`, z.union([z.boolean(), z.number()])).parse({ line: [`--no-xee`] })
+  const args = Command.create()
+    .parameter(`xee`, z.union([z.boolean(), z.number()]))
+    .parse({ line: [`--no-xee`] })
   expect(typeof args.xee).toBe(`boolean`)
   expect(args.xee).toBe(false)
 })
 
 it(`spec of number|boolean parses arg as boolean false if environment false given`, () => {
-  const args = Command.parameter(`xee`, z.union([z.boolean(), z.number()])).parse({
-    environment: { cli_param_xee: `false` },
-  })
+  const args = Command.create()
+    .parameter(`xee`, z.union([z.boolean(), z.number()]))
+    .parse({
+      environment: { cli_param_xee: `false` },
+    })
   expect(typeof args.xee).toBe(`boolean`)
   expect(args.xee).toBe(false)
 })
 
 it(`spec of number|boolean parses arg as boolean true if environment true given`, () => {
-  const args = Command.parameter(`xee`, z.union([z.boolean(), z.number()])).parse({
-    environment: { cli_param_xee: `true` },
-  })
+  const args = Command.create()
+    .parameter(`xee`, z.union([z.boolean(), z.number()]))
+    .parse({
+      environment: { cli_param_xee: `true` },
+    })
   expect(typeof args.xee).toBe(`boolean`)
   expect(args.xee).toBe(true)
 })
 
 it(`can use the .or method api sugar of zod`, () => {
-  const args = Command.parameter(`xee`, z.boolean().or(z.number())).parse({
-    environment: { cli_param_xee: `true` },
-  })
+  const args = Command.create()
+    .parameter(`xee`, z.boolean().or(z.number()))
+    .parse({
+      environment: { cli_param_xee: `true` },
+    })
   expectType<boolean | number>(args.xee)
   expect(typeof args.xee).toBe(`boolean`)
   expect(args.xee).toBe(true)

--- a/packages/@molt/command/tests/prompt/settings.spec.ts
+++ b/packages/@molt/command/tests/prompt/settings.spec.ts
@@ -12,7 +12,8 @@ describe(`parameter level`, () => {
   it(`can be passed object`, () => {
     tty.mock.input.add([`foo`])
     const args = tryCatch(() =>
-      Command.parameter(`a`, { schema: s, prompt: { enabled: true } })
+      Command.create()
+        .parameter(`a`, { schema: s, prompt: { enabled: true } })
         .settings({ onError: `throw`, helpOnError: false })
         .parse({ line: [], tty: tty.interface }),
     )
@@ -25,7 +26,8 @@ describe(`parameter level`, () => {
 describe(`command level`, () => {
   it(`passing object makes enabled default to true`, () => {
     tty.mock.input.add([`foo`])
-    const args = Command.parameter(`a`, { schema: s })
+    const args = Command.create()
+      .parameter(`a`, { schema: s })
       .settings({ onError: `throw`, helpOnError: false, prompt: { when: { result: `rejected` } } })
       .parse({ line: [], tty: tty.interface })
     expect(args).toMatchSnapshot(`args`)
@@ -36,7 +38,8 @@ describe(`command level`, () => {
 
 it(`prompt is disabled by default`, () => {
   const args = tryCatch(() =>
-    Command.parameter(`a`, { schema: s })
+    Command.create()
+      .parameter(`a`, { schema: s })
       .settings({ onError: `throw`, helpOnError: false })
       .parse({ line: [], tty: tty.interface }),
   )
@@ -48,7 +51,8 @@ it(`prompt is disabled by default`, () => {
 it(`prompt can be enabled by default`, () => {
   tty.mock.input.add([`foo`])
   const args = tryCatch(() =>
-    Command.parameter(`a`, { schema: s })
+    Command.create()
+      .parameter(`a`, { schema: s })
       .settings({ onError: `throw`, helpOnError: false, prompt: { enabled: true } })
       .parse({ line: [], tty: tty.interface }),
   )
@@ -59,7 +63,8 @@ it(`prompt can be enabled by default`, () => {
 
 it(`parameter settings overrides default settings`, () => {
   const args = tryCatch(() =>
-    Command.parameter(`a`, { schema: s, prompt: false })
+    Command.create()
+      .parameter(`a`, { schema: s, prompt: false })
       .settings({ onError: `throw`, helpOnError: false, prompt: { enabled: true } })
       .parse({ line: [], tty: tty.interface }),
   )
@@ -77,7 +82,8 @@ describe(`prompt can be toggled by check on error`, () => {
     it(`check does match`, () => {
       tty.mock.input.add([`foo`])
       const args = tryCatch(() =>
-        Command.parameter(`a`, { schema: s })
+        Command.create()
+          .parameter(`a`, { schema: s })
           .settings({ onError: `throw`, helpOnError: false, prompt: settings })
           .parse({ line: [], tty: tty.interface }),
       )
@@ -87,7 +93,8 @@ describe(`prompt can be toggled by check on error`, () => {
     })
     it(`check does not match`, () => {
       const args = tryCatch(() =>
-        Command.parameter(`b`, { schema: s })
+        Command.create()
+          .parameter(`b`, { schema: s })
           .settings({ onError: `throw`, helpOnError: false, prompt: settings })
           .parse({ line: [], tty: tty.interface }),
       )
@@ -101,7 +108,8 @@ describe(`prompt can be toggled by check on error`, () => {
 it(`parameter defaults to custom settings`, () => {
   tty.mock.input.add([`foo`])
   const args = tryCatch(() =>
-    Command.parameter(`a`, { schema: s })
+    Command.create()
+      .parameter(`a`, { schema: s })
       .settings({
         onError: `throw`,
         helpOnError: false,
@@ -137,7 +145,8 @@ it(`can be stack of conditional prompts`, () => {
   })
   tty.mock.input.add([`foo`])
   const args = tryCatch(() =>
-    Command.parameter(`a`, { schema: s.optional() })
+    Command.create()
+      .parameter(`a`, { schema: s.optional() })
       .settings({ onError: `throw`, helpOnError: false, prompt: settings })
       .parse({ line: [`-a`, `1`], tty: tty.interface }),
   )

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -10,7 +10,7 @@ import semverRegex from 'semver-regex'
 import { z } from 'zod'
 
 // prettier-ignore
-const args = Command
+const args = Command.create()
   .parameter(`githubToken`, z.string())
   .parameter(`publish`, z.boolean().default(true))
   .parameter(`githubRelease`, z.boolean().default(true))


### PR DESCRIPTION
This PR changes the Command API such that there is only one entrypoint for
starting a chain now, which is, `.create()`. It is not longer possible to
begin chains with `.describe()`, `.parameter()` etc.

The primary motivationf or this was for prettier formatting of chaining
API code. It keeps the first method call on the same ling as the namespace
`Command` and therefore created a lack of symmetry for example with how
the first `.paramter` method rendered versus all subsequent ones.

Another benefit of this is arguably a simpler less magical API.

#### TASKS

- [x] Out of band docs (website, README, ...)
- [x] In of band docs (jsdoc)
- [x] Tests
