### PR TITLE
feat(@molt/command): make prompts async

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,5 @@
     // Disable this because it will conflict with ESLint based import organizing.
     "source.organizeImports": false
   },
-  "vitest.commandLine": "",
-  "eslint.enable": false
+  "vitest.commandLine": ""
 }

--- a/packages/@molt/command/README.md
+++ b/packages/@molt/command/README.md
@@ -510,7 +510,7 @@ $ mybin --filePath ./a/b/c.yaml
 - The default pattern may be changed.
 - The default settings are:
   ```ts
-  Command.settings({
+  Command.create().settings({
     prompt: {
       enabled: false,
       when: Command.eventPatterns.rejectedMissingOrInvalid,
@@ -519,8 +519,7 @@ $ mybin --filePath ./a/b/c.yaml
   ```
 - When there is no `TTY` (`process.stdout.isTTY === false`) then prompts are always disabled.
 - Arguments are validated just like they are when given "up front". However, when invalid, the user will be shown an error message and re-prompted, instead of the process exiting non-zero.
-- Prompts are _synchronously_ executed allowing them to be used without forcing your users to write async CLI code.
-  - > 💡 This is achieved via the [`readline-sync`](https://github.com/anseki/readline-sync). That project's repository is archived and the package not maintained. We may try [prompt-sync](`https://github.com/heapwolf/prompt-sync`) but it also does not look actively maintained. Worst case Molt Command will need its own implementation or move to an async API.
+- Prompts are _asynchronously_ executed so you must `await` the return of `.parse()`.
 
 #### Conditional
 
@@ -545,7 +544,7 @@ All you need to do is pass a _pattern_ to `prompt` either at the parameter level
 Each event type share some core properties but also have their own unique fields. For example with `Accepted` you can match against what the value given was and with `Rejected` you can match against the specific error that occurred.
 
 ```ts
-const args = Command.create()
+const args = await Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
@@ -566,7 +565,7 @@ The pattern matching library will be open-sourced and thoroughly documented in t
 Passing `true` will enable using the default event pattern.
 
 ```ts
-const args = Command.create()
+const args = await Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
@@ -580,7 +579,7 @@ const args = Command.create()
 You can enable prompt when one of the built-in event patterns occur:
 
 ```ts
-const args = Command.create()
+const args = await Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
@@ -594,7 +593,7 @@ const args = Command.create()
 Or when one of multiple events occurs:
 
 ```ts
-const args = Command.create()
+const args = await Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
@@ -610,7 +609,7 @@ const args = Command.create()
 You can enable prompt when your given _event pattern_ occurs.
 
 ```ts
-const args = Command.create()
+const args = await Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, {
     schema: z.enum([`json`, `yaml`, `toml`]),
@@ -632,7 +631,7 @@ You can configure prompts for the entire instance in the settings. The configura
 Enable explicitly with shorthand approach using a `boolean`:
 
 ```ts
-const args = Command.create()
+const args = await Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, z.enum([`json`, `yaml`, `toml`]))
   .settings({ prompt: true })
@@ -644,7 +643,7 @@ Enable explicitly with longhand approach using the `enabled` nested property and
 Note that in the following `enabled` could be omitted because passing an object implies `enabled: true` by default.
 
 ```ts
-const args = Command.create()
+const args = await Command.create()
   .parameter(`filePath`, z.string())
   .parameter(`to`, z.enum([`json`, `yaml`, `toml`]))
   .settings({
@@ -1023,7 +1022,7 @@ You can control certain settings about the command centrally using the `.setting
 Settings documentation is not co-located. Documentation for various features will mention when there are command level settings available.
 
 ```ts
-Command.settings({...})
+Command.create().settings({...})
 ```
 
 ## Recipes

--- a/packages/@molt/command/examples/intro.ts
+++ b/packages/@molt/command/examples/intro.ts
@@ -1,7 +1,7 @@
 import { Command } from '../src/index.js'
 import { z } from 'zod'
 
-const args = Command.create()
+const args = await Command.create()
   .parameter(`filePath`, z.string().describe(`Path to the file to convert.`))
   .parameter(`to`, z.enum([`json`, `yaml`, `toml`]).describe(`Format to convert to.`))
   .parameter(`from`, {

--- a/packages/@molt/command/src/Builder/root/types.ts
+++ b/packages/@molt/command/src/Builder/root/types.ts
@@ -17,6 +17,26 @@ export interface ParameterConfiguration {
   prompt?: ParameterSpec.Input.Prompt<this['schema']>
 }
 
+export type IsHasKey<Obj extends object, Key> = Key extends keyof Obj ? true : false
+
+// prettier-ignore
+export type IsPromptEnabledInParameterSettings<P extends ParameterConfiguration> =
+  IsHasKey<P,'prompt'>                                      extends false     ? false :
+                                                                                IsPromptEnabled<P['prompt']>
+// prettier-ignore
+export type IsPromptEnabledInCommandSettings<P extends Settings.Input<any>> =
+  IsHasKey<P,'prompt'>                                      extends false     ? false :
+                                                                                IsPromptEnabled<P['prompt']>
+
+// prettier-ignore
+export type IsPromptEnabled<P extends ParameterSpec.Input.Prompt<any>|undefined> =
+  P                                               extends undefined ? false :
+  P                                               extends false     ? false :
+  P                                               extends true      ? true  :
+  P                                               extends null      ? false :
+  Exclude<P, undefined|boolean|null>['enabled']   extends false     ? false :
+                                                                      true
+
 export interface SomeParameterConfig<S extends Schema> {
   schema: S
   prompt?: ParameterSpec.Input.Prompt<S>
@@ -24,22 +44,31 @@ export interface SomeParameterConfig<S extends Schema> {
 
 // prettier-ignore
 export interface RootBuilder<State extends State.Base = State.BaseEmpty> {
+  s: State
   description                                                                               (this:void, description:string):
     RootBuilder<State>
-  parameter<NameExpression extends string, Configuration extends ParameterConfiguration>    (this:void, name:State.ValidateNameExpression<State,NameExpression>, configuration:Configuration):
+  parameter<NameExpression extends string, const Configuration extends ParameterConfiguration>    (this:void, name:State.ValidateNameExpression<State,NameExpression>, configuration:Configuration):
+    // {x:IsPromptEnabledInConfiguration<Configuration>,y:Configuration}
+
     RootBuilder<{
+      IsPromptEnabled    : State['IsPromptEnabled'] extends true ? true : IsPromptEnabledInParameterSettings<Configuration>
       ParametersExclusive: State['ParametersExclusive']
       Parameters         : State['Parameters'] & { [_ in NameExpression]: State.CreateParameter<State,NameExpression,Configuration> }
     }>
   parameter<NameExpression extends string, S extends Schema>                                (this:void, name:State.ValidateNameExpression<State,NameExpression>, schema:S):
     RootBuilder<{
+      IsPromptEnabled    : State['IsPromptEnabled']
       ParametersExclusive: State['ParametersExclusive']
       Parameters         : State['Parameters'] & { [_ in NameExpression]: State.CreateParameter<State,NameExpression,{schema:S}> }
     }>
   parametersExclusive<Label extends string, BuilderExclusive extends SomeBuilderExclusive>  (this:void, label:Label, ExclusiveBuilderContainer: (builder:BuilderExclusiveInitial<State,Label>) => BuilderExclusive):
     RootBuilder<BuilderExclusive['_']['typeState']>
-  settings                                                                                  (this:void, newSettings:Settings.Input<State.ToSchema<State>>):
-    BuilderAfterSettings<State>
+  settings                                                                                  <S extends Settings.Input<State.ToSchema<State>>>(this:void, newSettings:S):
+    BuilderAfterSettings<{
+      IsPromptEnabled    : State['IsPromptEnabled'] extends true ? true : IsPromptEnabledInCommandSettings<S>
+      ParametersExclusive: State['ParametersExclusive']
+      Parameters         : State['Parameters']
+    }>
   parse                                                                                     (this:void, inputs?:RawArgInputs):
     State.ToArgs<State>
 }

--- a/packages/@molt/command/src/lib/prelude.ts
+++ b/packages/@molt/command/src/lib/prelude.ts
@@ -1,3 +1,16 @@
+export const isPromiseLikeValue = (value: unknown): value is Promise<unknown> => {
+  return (
+    typeof value === `object` &&
+    value !== null &&
+    `then` in value &&
+    typeof value.then === `function` &&
+    `catch` in value &&
+    typeof value.catch === `function` &&
+    `finally` in value &&
+    typeof value.finally === `function`
+  )
+}
+
 export type Index<T> = Record<string, T>
 
 export type RequireField<O extends object, F extends keyof O> = O & {

--- a/packages/@molt/command/src/parse/prompt.ts
+++ b/packages/@molt/command/src/parse/prompt.ts
@@ -16,8 +16,8 @@ export interface TTY {
 export const prompt = (
   parseProgress: ParseProgressPostPromptAnnotation,
   tty: null | TTY,
-): ParseProgressPostPrompt => {
-  if (tty === null) return parseProgress as ParseProgressPostPrompt
+): Promise<ParseProgressPostPrompt> => {
+  if (tty === null) return Promise.resolve(parseProgress as ParseProgressPostPrompt)
 
   const args: Record<string, any> = {}
   const specs = Object.entries(parseProgress.basicParameters)
@@ -65,7 +65,7 @@ export const prompt = (
     parseProgressPostPrompt.basicParameters[parameterName]!.prompt.arg = arg // eslint-disable-line
   }
 
-  return parseProgressPostPrompt
+  return Promise.resolve(parseProgressPostPrompt)
 }
 
 /**

--- a/packages/@molt/command/tests/line/types/zod/number.spec.ts
+++ b/packages/@molt/command/tests/line/types/zod/number.spec.ts
@@ -17,10 +17,13 @@ describe(`zod`, () => {
       ],
     )(`%s`, (_, parameters, input) => {
       expect(() => {
+        // eslint-disable-next-line
         Object.entries(parameters)
+          // @ts-expect-error todo
           .reduce((chain, data) => {
             return chain.parameter(data[0] as any, data[1])
           }, Command.create())
+          // @ts-expect-error todo
           .settings({ onError: `throw`, helpOnError: false })
           .parse(input)
       }).toThrowErrorMatchingSnapshot()

--- a/packages/@molt/command/tests/prompt/settings.spec.ts
+++ b/packages/@molt/command/tests/prompt/settings.spec.ts
@@ -9,9 +9,9 @@ import { describe, expect, it } from 'vitest'
 const S = <S extends ParameterSpec.Input.Schema>(settings: Settings.InputPrompt<S>) => settings
 
 describe(`parameter level`, () => {
-  it(`can be passed object`, () => {
+  it(`can be passed object`, async () => {
     tty.mock.input.add([`foo`])
-    const args = tryCatch(() =>
+    const args = await tryCatch(() =>
       Command.create()
         .parameter(`a`, { schema: s, prompt: { enabled: true } })
         .settings({ onError: `throw`, helpOnError: false })
@@ -24,9 +24,10 @@ describe(`parameter level`, () => {
 })
 
 describe(`command level`, () => {
-  it(`passing object makes enabled default to true`, () => {
+  it(`passing object makes enabled default to true`, async () => {
     tty.mock.input.add([`foo`])
-    const args = Command.create()
+    // eslint-disable-next-line
+    const args = await Command.create()
       .parameter(`a`, { schema: s })
       .settings({ onError: `throw`, helpOnError: false, prompt: { when: { result: `rejected` } } })
       .parse({ line: [], tty: tty.interface })
@@ -48,9 +49,9 @@ it(`prompt is disabled by default`, () => {
   expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
 })
 
-it(`prompt can be enabled by default`, () => {
+it(`prompt can be enabled by default`, async () => {
   tty.mock.input.add([`foo`])
-  const args = tryCatch(() =>
+  const args = await tryCatch(() =>
     Command.create()
       .parameter(`a`, { schema: s })
       .settings({ onError: `throw`, helpOnError: false, prompt: { enabled: true } })
@@ -79,9 +80,10 @@ describe(`prompt can be toggled by check on error`, () => {
       enabled: true,
       when: { result: `rejected`, error: `ErrorMissingArgument`, spec: { name: { canonical: `a` } } },
     })
-    it(`check does match`, () => {
+    it(`check does match`, async () => {
       tty.mock.input.add([`foo`])
-      const args = tryCatch(() =>
+      // eslint-disable-next-line
+      const args = await tryCatch(() =>
         Command.create()
           .parameter(`a`, { schema: s })
           .settings({ onError: `throw`, helpOnError: false, prompt: settings })
@@ -105,9 +107,9 @@ describe(`prompt can be toggled by check on error`, () => {
   })
 })
 
-it(`parameter defaults to custom settings`, () => {
+it(`parameter defaults to custom settings`, async () => {
   tty.mock.input.add([`foo`])
-  const args = tryCatch(() =>
+  const args = await tryCatch(() =>
     Command.create()
       .parameter(`a`, { schema: s })
       .settings({
@@ -128,7 +130,7 @@ it(`parameter defaults to custom settings`, () => {
   expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
 })
 
-it(`can be stack of conditional prompts`, () => {
+it(`can be stack of conditional prompts`, async () => {
   const settings = S({
     enabled: true,
     when: [
@@ -144,7 +146,8 @@ it(`can be stack of conditional prompts`, () => {
     ],
   })
   tty.mock.input.add([`foo`])
-  const args = tryCatch(() =>
+  // eslint-disable-next-line
+  const args = await tryCatch(() =>
     Command.create()
       .parameter(`a`, { schema: s.optional() })
       .settings({ onError: `throw`, helpOnError: false, prompt: settings })


### PR DESCRIPTION
This PR makes `.parse()` return a promise when prompts are in use.

This feature unlocks future work for making richer prompts than simply
a text input. For example a boolean toggle.

#### TASKS

- [x] Out of band docs (website, README, ...)
- [x] In of band docs (jsdoc)
- [x] Tests
