### PR TITLE
improve(@molt/command): make prompter be async

### DIFF
--- a/packages/@molt/command/package.json
+++ b/packages/@molt/command/package.json
@@ -48,7 +48,6 @@
     "chalk": "^5.3.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.snakecase": "^4.1.1",
-    "readline-sync": "^1.4.10",
     "string-length": "^6.0.0",
     "strip-ansi": "^7.1.0",
     "type-fest": "^4.3.1",
@@ -57,7 +56,6 @@
   "devDependencies": {
     "@types/lodash.camelcase": "4.3.7",
     "@types/lodash.snakecase": "^4.1.7",
-    "@types/readline-sync": "^1.4.4",
     "conditional-type-checks": "1.0.6",
     "execa": "8.0.1",
     "fast-glob": "3.3.1",

--- a/packages/@molt/command/src/Builder/root/types.ts
+++ b/packages/@molt/command/src/Builder/root/types.ts
@@ -1,6 +1,6 @@
 import type { OpeningArgs } from '../../OpeningArgs/index.js'
 import type { ParameterSpec } from '../../ParameterSpec/index.js'
-import type { TTY } from '../../parse/prompt.js'
+import type { Prompter } from '../../parse/prompt.js'
 import type { Settings } from '../../Settings/index.js'
 import type {
   BuilderAfterSettings,
@@ -74,7 +74,7 @@ export interface RootBuilder<State extends State.Base = State.BaseEmpty> {
 export type RawArgInputs = {
   line?: OpeningArgs.Line.RawInputs
   environment?: OpeningArgs.Environment.RawInputs
-  tty?: TTY
+  tty?: Prompter
 }
 
 export type SomeArgsNormalized = Record<string, unknown>

--- a/packages/@molt/command/src/parse/parse.ts
+++ b/packages/@molt/command/src/parse/parse.ts
@@ -3,7 +3,6 @@ import { createEvent } from '../eventPatterns.js'
 import { Help } from '../Help/index.js'
 import { getLowerCaseEnvironment, lowerCaseObjectKeys } from '../helpers.js'
 import type { Settings } from '../index.js'
-import { Text } from '../lib/Text/index.js'
 import { OpeningArgs } from '../OpeningArgs/index.js'
 import type {
   ParseResultBasicError,
@@ -12,8 +11,7 @@ import type {
 } from '../OpeningArgs/OpeningArgs.js'
 import { ParameterSpec } from '../ParameterSpec/index.js'
 import { match } from '../Pattern/Pattern.js'
-import { createPrompter, createStdioPrompter, prompt } from './prompt.js'
-import * as Readline from 'node:readline/promises'
+import { createStdioPrompter, prompt } from './prompt.js'
 
 export interface ParseProgressPostPromptAnnotation {
   globalErrors: OpeningArgs.ParseResult['globalErrors']

--- a/packages/@molt/command/src/parse/parse.ts
+++ b/packages/@molt/command/src/parse/parse.ts
@@ -3,6 +3,7 @@ import { createEvent } from '../eventPatterns.js'
 import { Help } from '../Help/index.js'
 import { getLowerCaseEnvironment, lowerCaseObjectKeys } from '../helpers.js'
 import type { Settings } from '../index.js'
+import { Text } from '../lib/Text/index.js'
 import { OpeningArgs } from '../OpeningArgs/index.js'
 import type {
   ParseResultBasicError,
@@ -11,8 +12,8 @@ import type {
 } from '../OpeningArgs/OpeningArgs.js'
 import { ParameterSpec } from '../ParameterSpec/index.js'
 import { match } from '../Pattern/Pattern.js'
-import { prompt } from './prompt.js'
-import * as ReadLineSync from 'readline-sync'
+import { createPrompter, createStdioPrompter, prompt } from './prompt.js'
+import * as Readline from 'node:readline/promises'
 
 export interface ParseProgressPostPromptAnnotation {
   globalErrors: OpeningArgs.ParseResult['globalErrors']
@@ -68,14 +69,7 @@ export const parse = (
   argInputs: RawArgInputs,
 ) => {
   const testDebuggingNoExit = process.env[`testing_molt`] === `true`
-  const argInputsTTY =
-    argInputs?.tty ??
-    (process.stdout.isTTY
-      ? {
-          output: console.log,
-          input: (params) => ReadLineSync.question(params.prompt),
-        }
-      : null)
+  const argInputsTTY = argInputs?.tty ?? (process.stdout.isTTY ? createStdioPrompter() : null)
   const argInputsLine = argInputs?.line ?? process.argv.slice(2)
   const argInputsEnvironment = argInputs?.environment
     ? lowerCaseObjectKeys(argInputs.environment)

--- a/packages/@molt/command/src/parse/prompt.ts
+++ b/packages/@molt/command/src/parse/prompt.ts
@@ -3,51 +3,61 @@ import { Text } from '../lib/Text/index.js'
 import { ParameterSpec } from '../ParameterSpec/index.js'
 import { Term } from '../term.js'
 import type { ParseProgressPostPrompt, ParseProgressPostPromptAnnotation } from './parse.js'
+import * as Readline from 'node:readline/promises'
 
-export interface TTY {
-  output: (text: string) => void
-  input: (params: { prompt: string }) => string
+export interface Prompter {
+  /**
+   * Send output to the user.
+   */
+  say: (text: string) => void
+  /**
+   * Receive input from the user.
+   * TODO remove prompt config from here.
+   */
+  ask: (params: { prompt: string; question: string }) => Promise<string>
 }
 
 /**
  * Get args from the user interactively via the console for the given parameters.
  */
 // export const prompt = (specs: ParameterSpec.Output[], tty: TTY): Record<string, any> => {
-export const prompt = (
+export const prompt = async (
   parseProgress: ParseProgressPostPromptAnnotation,
-  tty: null | TTY,
+  prompter: null | Prompter,
 ): Promise<ParseProgressPostPrompt> => {
-  if (tty === null) return Promise.resolve(parseProgress as ParseProgressPostPrompt)
+  if (prompter === null) return Promise.resolve(parseProgress as ParseProgressPostPrompt)
 
   const args: Record<string, any> = {}
-  const specs = Object.entries(parseProgress.basicParameters)
+  const parameterSpecs = Object.entries(parseProgress.basicParameters)
     .filter((_) => _[1].prompt.enabled)
     .map((_) => _[1].spec)
-  const indexTotal = specs.length
+  const indexTotal = parameterSpecs.length
   let indexCurrent = 1
   const gutterWidth = String(indexTotal).length * 2 + 3
 
-  for (const spec of specs) {
+  for (const param of parameterSpecs) {
     // prettier-ignore
     const question = Tex({ flow: `horizontal`})
         .block({ padding: { right: 2 }}, `${Term.colors.dim(`${indexCurrent}/${indexTotal}`)}`)
         .block((__) =>
-          __.block(Term.colors.positive(spec.name.canonical))
-            .block((spec.description && Term.colors.dim(spec.description)) ?? null)
+          __.block(Term.colors.positive(param.name.canonical))
+            .block((param.description && Term.colors.dim(param.description)) ?? null)
         )
       .render()
-    tty.output(question)
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const arg = tty.input({ prompt: `${Text.pad(`left`, gutterWidth, Text.chars.space, `❯ `)}` })
-      const validationResult = ParameterSpec.validate(spec, arg)
+      const arg = await prompter.ask({
+        question,
+        prompt: `${Text.pad(`left`, gutterWidth, Text.chars.space, `❯ `)}`,
+      })
+      const validationResult = ParameterSpec.validate(param, arg)
       if (validationResult._tag === `Success`) {
-        args[spec.name.canonical] = validationResult.value
-        tty.output(Text.chars.newline)
+        args[param.name.canonical] = validationResult.value
+        prompter.say(``) // newline
         indexCurrent++
         break
       } else {
-        tty.output(
+        prompter.say(
           Text.pad(
             `left`,
             gutterWidth,
@@ -68,54 +78,86 @@ export const prompt = (
   return Promise.resolve(parseProgressPostPrompt)
 }
 
+export const createPrompter = (channels: {
+  output: (value: string) => void
+  readLine: () => Promise<string>
+}) => {
+  const prompter: Prompter = {
+    say: (value: string) => {
+      channels.output(value + Text.chars.newline)
+    },
+    ask: async (params) => {
+      channels.output(params.question + Text.chars.newline + params.prompt)
+      const answer = await channels.readLine()
+      return answer
+    },
+  }
+  return prompter
+}
+
 /**
  * A utility for testing prompts. It allows programmatic control of
  * the input and capturing of the output of a prompts session.
  */
-export const createMockTTY = () => {
+export const createMemoryPrompter = () => {
   const state: {
     inputScript: string[]
     history: {
       output: string[]
-      input: string[]
+      answers: string[]
       all: string[]
     }
   } = {
     inputScript: [],
     history: {
-      input: [],
+      answers: [],
       output: [],
       all: [],
     },
   }
-  const tty: TTY = {
+  const prompter: Prompter = createPrompter({
     output: (value) => {
       state.history.output.push(value)
       state.history.all.push(value)
     },
-    input: () => {
+    readLine: async () => {
       const value = state.inputScript.shift()
       if (value === undefined) {
         throw new Error(`No more values in read script.`)
       }
-      state.history.input.push(value)
+      state.history.answers.push(value)
       state.history.all.push(value)
-      return value
+      return Promise.resolve(value)
     },
-  }
+  })
   return {
     // state,
     history: state.history,
-    mock: {
-      input: {
-        add: (values: string[]) => {
-          state.inputScript.push(...values)
-        },
-        get: () => state.inputScript,
+    answers: {
+      add: (values: string[]) => {
+        state.inputScript.push(...values)
       },
+      get: () => state.inputScript,
     },
-    interface: tty,
+    ...prompter,
   }
 }
 
-export type MockTTY = ReturnType<typeof createMockTTY>
+export type MemoryPrompter = ReturnType<typeof createMemoryPrompter>
+
+export const createStdioPrompter = () => {
+  return createPrompter({
+    output: (value) => process.stdout.write(value),
+    readLine: () => {
+      return new Promise((res) => {
+        const lineReader = Readline.createInterface({
+          input: process.stdin,
+        })
+        lineReader.once(`line`, (value) => {
+          lineReader.close()
+          res(value)
+        })
+      })
+    },
+  })
+}

--- a/packages/@molt/command/tests/_/mocks/tty.ts
+++ b/packages/@molt/command/tests/_/mocks/tty.ts
@@ -1,13 +1,13 @@
-import type { MockTTY } from '../../../src/parse/prompt.js'
-import { createMockTTY } from '../../../src/parse/prompt.js'
+import type { MemoryPrompter } from '../../../src/parse/prompt.js'
+import { createMemoryPrompter } from '../../../src/parse/prompt.js'
 import { afterEach, beforeEach, expect } from 'vitest'
 
-export let tty: MockTTY
+export let memoryPrompter: MemoryPrompter
 
 beforeEach(() => {
-  tty = createMockTTY()
+  memoryPrompter = createMemoryPrompter()
 })
 
 afterEach(() => {
-  expect(tty.mock.input.get()).toEqual([])
+  expect(memoryPrompter.answers.get()).toEqual([])
 })

--- a/packages/@molt/command/tests/prompt/__snapshots__/prompt.spec.ts.snap
+++ b/packages/@molt/command/tests/prompt/__snapshots__/prompt.spec.ts.snap
@@ -21,7 +21,8 @@ exports[`prompt when invalid input > args 1`] = `
 
 exports[`prompt when invalid input > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -30,7 +31,8 @@ exports[`prompt when invalid input > tty 1`] = `
 
 exports[`prompt when invalid input > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",
@@ -46,7 +48,8 @@ exports[`prompt when invalid input OR missing input > args 1`] = `
 
 exports[`prompt when invalid input OR missing input > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -55,7 +58,8 @@ exports[`prompt when invalid input OR missing input > tty 1`] = `
 
 exports[`prompt when invalid input OR missing input > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",
@@ -71,7 +75,8 @@ exports[`prompt when missing input > args 1`] = `
 
 exports[`prompt when missing input > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -80,7 +85,8 @@ exports[`prompt when missing input > tty 1`] = `
 
 exports[`prompt when missing input > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",
@@ -96,7 +102,8 @@ exports[`prompt when omitted > args 1`] = `
 
 exports[`prompt when omitted > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -105,7 +112,8 @@ exports[`prompt when omitted > tty 1`] = `
 
 exports[`prompt when omitted > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",

--- a/packages/@molt/command/tests/prompt/__snapshots__/settings.spec.ts.snap
+++ b/packages/@molt/command/tests/prompt/__snapshots__/settings.spec.ts.snap
@@ -9,7 +9,8 @@ exports[`can be stack of conditional prompts > args 1`] = `
 
 exports[`can be stack of conditional prompts > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -18,7 +19,8 @@ exports[`can be stack of conditional prompts > tty 1`] = `
 
 exports[`can be stack of conditional prompts > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",
@@ -34,7 +36,8 @@ exports[`command level > passing object makes enabled default to true > args 1`]
 
 exports[`command level > passing object makes enabled default to true > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -43,7 +46,8 @@ exports[`command level > passing object makes enabled default to true > tty 1`] 
 
 exports[`command level > passing object makes enabled default to true > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",
@@ -59,7 +63,8 @@ exports[`parameter defaults to custom settings > args 1`] = `
 
 exports[`parameter defaults to custom settings > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -68,7 +73,8 @@ exports[`parameter defaults to custom settings > tty 1`] = `
 
 exports[`parameter defaults to custom settings > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",
@@ -84,7 +90,8 @@ exports[`parameter level > can be passed object > args 1`] = `
 
 exports[`parameter level > can be passed object > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -93,7 +100,8 @@ exports[`parameter level > can be passed object > tty 1`] = `
 
 exports[`parameter level > can be passed object > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",
@@ -115,7 +123,8 @@ exports[`prompt can be enabled by default > args 1`] = `
 
 exports[`prompt can be enabled by default > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -124,7 +133,8 @@ exports[`prompt can be enabled by default > tty 1`] = `
 
 exports[`prompt can be enabled by default > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",
@@ -140,7 +150,8 @@ exports[`prompt can be toggled by check on error > toggle to enabled > check doe
 
 exports[`prompt can be toggled by check on error > toggle to enabled > check does match > tty 1`] = `
 [
-  "[2m[90m1/1[39m[22m  [32ma[39m",
+  "[2m[90m1/1[39m[22m  [32ma[39m
+     ❯ ",
   "foo",
   "
 ",
@@ -149,7 +160,8 @@ exports[`prompt can be toggled by check on error > toggle to enabled > check doe
 
 exports[`prompt can be toggled by check on error > toggle to enabled > check does match > tty strip ansi 1`] = `
 [
-  "1/1  a",
+  "1/1  a
+     ❯ ",
   "foo",
   "
 ",

--- a/packages/@molt/command/tests/prompt/settings.spec.ts
+++ b/packages/@molt/command/tests/prompt/settings.spec.ts
@@ -2,7 +2,7 @@ import type { Settings } from '../../src/index.js'
 import { Command } from '../../src/index.js'
 import type { ParameterSpec } from '../../src/ParameterSpec/index.js'
 import { s, tryCatch } from '../_/helpers.js'
-import { tty } from '../_/mocks/tty.js'
+import { memoryPrompter } from '../_/mocks/tty.js'
 import stripAnsi from 'strip-ansi'
 import { describe, expect, it } from 'vitest'
 
@@ -10,30 +10,30 @@ const S = <S extends ParameterSpec.Input.Schema>(settings: Settings.InputPrompt<
 
 describe(`parameter level`, () => {
   it(`can be passed object`, async () => {
-    tty.mock.input.add([`foo`])
+    memoryPrompter.answers.add([`foo`])
     const args = await tryCatch(() =>
       Command.create()
         .parameter(`a`, { schema: s, prompt: { enabled: true } })
         .settings({ onError: `throw`, helpOnError: false })
-        .parse({ line: [], tty: tty.interface }),
+        .parse({ line: [], tty: memoryPrompter }),
     )
     expect(args).toMatchSnapshot(`args`)
-    expect(tty.history.all).toMatchSnapshot(`tty`)
-    expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+    expect(memoryPrompter.history.all).toMatchSnapshot(`tty`)
+    expect(memoryPrompter.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
   })
 })
 
 describe(`command level`, () => {
   it(`passing object makes enabled default to true`, async () => {
-    tty.mock.input.add([`foo`])
+    memoryPrompter.answers.add([`foo`])
     // eslint-disable-next-line
     const args = await Command.create()
       .parameter(`a`, { schema: s })
       .settings({ onError: `throw`, helpOnError: false, prompt: { when: { result: `rejected` } } })
-      .parse({ line: [], tty: tty.interface })
+      .parse({ line: [], tty: memoryPrompter })
     expect(args).toMatchSnapshot(`args`)
-    expect(tty.history.all).toMatchSnapshot(`tty`)
-    expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+    expect(memoryPrompter.history.all).toMatchSnapshot(`tty`)
+    expect(memoryPrompter.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
   })
 })
 
@@ -42,24 +42,24 @@ it(`prompt is disabled by default`, () => {
     Command.create()
       .parameter(`a`, { schema: s })
       .settings({ onError: `throw`, helpOnError: false })
-      .parse({ line: [], tty: tty.interface }),
+      .parse({ line: [], tty: memoryPrompter }),
   )
   expect(args).toMatchSnapshot(`args`)
-  expect(tty.history.all).toMatchSnapshot(`tty`)
-  expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+  expect(memoryPrompter.history.all).toMatchSnapshot(`tty`)
+  expect(memoryPrompter.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
 })
 
 it(`prompt can be enabled by default`, async () => {
-  tty.mock.input.add([`foo`])
+  memoryPrompter.answers.add([`foo`])
   const args = await tryCatch(() =>
     Command.create()
       .parameter(`a`, { schema: s })
       .settings({ onError: `throw`, helpOnError: false, prompt: { enabled: true } })
-      .parse({ line: [], tty: tty.interface }),
+      .parse({ line: [], tty: memoryPrompter }),
   )
   expect(args).toMatchSnapshot(`args`)
-  expect(tty.history.all).toMatchSnapshot(`tty`)
-  expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+  expect(memoryPrompter.history.all).toMatchSnapshot(`tty`)
+  expect(memoryPrompter.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
 })
 
 it(`parameter settings overrides default settings`, () => {
@@ -67,11 +67,11 @@ it(`parameter settings overrides default settings`, () => {
     Command.create()
       .parameter(`a`, { schema: s, prompt: false })
       .settings({ onError: `throw`, helpOnError: false, prompt: { enabled: true } })
-      .parse({ line: [], tty: tty.interface }),
+      .parse({ line: [], tty: memoryPrompter }),
   )
   expect(args).toMatchSnapshot(`args`)
-  expect(tty.history.all).toMatchSnapshot(`tty`)
-  expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+  expect(memoryPrompter.history.all).toMatchSnapshot(`tty`)
+  expect(memoryPrompter.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
 })
 
 describe(`prompt can be toggled by check on error`, () => {
@@ -81,34 +81,34 @@ describe(`prompt can be toggled by check on error`, () => {
       when: { result: `rejected`, error: `ErrorMissingArgument`, spec: { name: { canonical: `a` } } },
     })
     it(`check does match`, async () => {
-      tty.mock.input.add([`foo`])
+      memoryPrompter.answers.add([`foo`])
       // eslint-disable-next-line
       const args = await tryCatch(() =>
         Command.create()
           .parameter(`a`, { schema: s })
           .settings({ onError: `throw`, helpOnError: false, prompt: settings })
-          .parse({ line: [], tty: tty.interface }),
+          .parse({ line: [], tty: memoryPrompter }),
       )
       expect(args).toMatchSnapshot(`args`)
-      expect(tty.history.all).toMatchSnapshot(`tty`)
-      expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+      expect(memoryPrompter.history.all).toMatchSnapshot(`tty`)
+      expect(memoryPrompter.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
     })
     it(`check does not match`, () => {
       const args = tryCatch(() =>
         Command.create()
           .parameter(`b`, { schema: s })
           .settings({ onError: `throw`, helpOnError: false, prompt: settings })
-          .parse({ line: [], tty: tty.interface }),
+          .parse({ line: [], tty: memoryPrompter }),
       )
       expect(args).toMatchSnapshot(`args`)
-      expect(tty.history.all).toMatchSnapshot(`tty`)
-      expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+      expect(memoryPrompter.history.all).toMatchSnapshot(`tty`)
+      expect(memoryPrompter.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
     })
   })
 })
 
 it(`parameter defaults to custom settings`, async () => {
-  tty.mock.input.add([`foo`])
+  memoryPrompter.answers.add([`foo`])
   const args = await tryCatch(() =>
     Command.create()
       .parameter(`a`, { schema: s })
@@ -123,11 +123,11 @@ it(`parameter defaults to custom settings`, async () => {
           },
         },
       })
-      .parse({ line: [], tty: tty.interface }),
+      .parse({ line: [], tty: memoryPrompter }),
   )
   expect(args).toMatchSnapshot(`args`)
-  expect(tty.history.all).toMatchSnapshot(`tty`)
-  expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+  expect(memoryPrompter.history.all).toMatchSnapshot(`tty`)
+  expect(memoryPrompter.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
 })
 
 it(`can be stack of conditional prompts`, async () => {
@@ -145,15 +145,15 @@ it(`can be stack of conditional prompts`, async () => {
       },
     ],
   })
-  tty.mock.input.add([`foo`])
+  memoryPrompter.answers.add([`foo`])
   // eslint-disable-next-line
   const args = await tryCatch(() =>
     Command.create()
       .parameter(`a`, { schema: s.optional() })
       .settings({ onError: `throw`, helpOnError: false, prompt: settings })
-      .parse({ line: [`-a`, `1`], tty: tty.interface }),
+      .parse({ line: [`-a`, `1`], tty: memoryPrompter }),
   )
   expect(args).toMatchSnapshot(`args`)
-  expect(tty.history.all).toMatchSnapshot(`tty`)
-  expect(tty.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
+  expect(memoryPrompter.history.all).toMatchSnapshot(`tty`)
+  expect(memoryPrompter.history.all.map((_) => stripAnsi(_))).toMatchSnapshot(`tty strip ansi`)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,9 +120,6 @@ importers:
       lodash.snakecase:
         specifier: ^4.1.1
         version: 4.1.1
-      readline-sync:
-        specifier: ^1.4.10
-        version: 1.4.10
       string-length:
         specifier: ^6.0.0
         version: 6.0.0
@@ -142,9 +139,6 @@ importers:
       '@types/lodash.snakecase':
         specifier: ^4.1.7
         version: 4.1.7
-      '@types/readline-sync':
-        specifier: ^1.4.4
-        version: 1.4.4
       conditional-type-checks:
         specifier: 1.0.6
         version: 1.0.6
@@ -823,10 +817,6 @@ packages:
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
-    dev: true
-
-  /@types/readline-sync@1.4.4:
-    resolution: {integrity: sha512-cFjVIoiamX7U6zkO2VPvXyTxbFDdiRo902IarJuPVxBhpDnXhwSaVE86ip+SCuyWBbEioKCkT4C88RNTxBM1Dw==}
     dev: true
 
   /@types/semver@7.5.2:
@@ -2678,11 +2668,6 @@ packages:
     dependencies:
       picomatch: 2.3.1
     dev: true
-
-  /readline-sync@1.4.10:
-    resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
-    engines: {node: '>= 0.8.0'}
-    dev: false
 
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}


### PR DESCRIPTION
This PR makes the prompter be async. This opens up more features like interactive prompt adapted for different kinds of parameters, e.g. toggle for a boolean