### PR TITLE
feat(@molt/command): interactive boolean prompt UI

### DIFF
--- a/packages/@molt/command/README.md
+++ b/packages/@molt/command/README.md
@@ -528,12 +528,17 @@ $ mybin --filePath ./a/b/c.yaml
 - By default, disabled.
 - Can be configured at parameter level _or_ command level. Parameter level overrides command level.
 - Only _basic_ parameters support prompting (so e.g. not [mutually exclusive parameters](#mutually-exclusive-parameters)).
+- Prompt interaction honours the parameter type. For example here is an example for boolean:
+  ```
+  1/3  verbose
+       ❯ no / yes
+  ```
 - Can be enabled _conditionally_ via _pattern matching_ on _events_.
-- Common patterns have been pre-defined and exported at `Command.eventPatterns` for you.
-- Custom patterns may be defined in a type-safe way.
-- When enabled, a default pattern is used when none explicitly set.
+  - Common patterns have been pre-defined and exported at `Command.eventPatterns` for you.
+  - Custom patterns may be defined in a type-safe way.
 - The order of prompts will match the order of your parameter definitions.
-- The default pattern may be changed.
+- When enabled, a default pattern is used when none explicitly set.
+  - The default pattern may be changed.
 - The default settings are:
   ```ts
   Command.create().settings({

--- a/packages/@molt/command/examples/prompt.ts
+++ b/packages/@molt/command/examples/prompt.ts
@@ -1,0 +1,12 @@
+import { Command } from '../src/index.js'
+import { z } from 'zod'
+
+const args = await Command.create()
+  .parameter(`alpha`, z.string())
+  .parameter(`bravo`, z.number())
+  .parameter(`charlie`, z.boolean())
+  .settings({ prompt: true })
+  .parse()
+
+console.log()
+console.log(args)

--- a/packages/@molt/command/package.json
+++ b/packages/@molt/command/package.json
@@ -14,6 +14,7 @@
     "build:toc": "markdown-toc README.md -i --maxdepth 4 && prettier --write README.md",
     "prepublishOnly": "pnpm build",
     "examples:intro": "tsx examples/intro.ts",
+    "examples:prompt": "tsx examples/prompt.ts",
     "examples:kitchen-sink": "tsx examples/kitchen-sink.ts",
     "examples:publish": "tsx examples/publish.ts"
   },
@@ -45,6 +46,7 @@
   "dependencies": {
     "@molt/types": "workspace:*",
     "alge": "0.8.1",
+    "ansi-escapes": "^6.2.0",
     "chalk": "^5.3.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.snakecase": "^4.1.1",

--- a/packages/@molt/command/src/lib/KeyPress/KeyPress.ts
+++ b/packages/@molt/command/src/lib/KeyPress/KeyPress.ts
@@ -1,0 +1,41 @@
+import { stdin, stdout } from 'node:process'
+import * as Readline from 'node:readline'
+
+export interface KeyPressEvent<Name extends string = string> {
+  name: Name
+  ctrl: boolean
+  meta: boolean
+  shift: boolean
+  sequence: string
+}
+
+export const get = async (): Promise<KeyPressEvent> => {
+  const rl = Readline.promises.createInterface({
+    input: stdin,
+    output: stdout,
+    terminal: false,
+  })
+  stdin.setRawMode(true)
+  Readline.emitKeypressEvents(stdin, rl)
+
+  let listener: (...args: any[]) => void
+
+  return new Promise((resolve) => {
+    listener = (k, e) => {
+      rl.close()
+      stdin.removeListener(`keypress`, listener)
+      resolve(e)
+    }
+    stdin.on(`keypress`, listener)
+  })
+}
+
+export async function* watch(): AsyncGenerator<KeyPressEvent> {
+  while (true) {
+    const event = await get()
+    if (event.name == `c` && event.ctrl == true) {
+      process.exit()
+    }
+    yield event
+  }
+}

--- a/packages/@molt/command/src/lib/KeyPress/KeyPress.ts
+++ b/packages/@molt/command/src/lib/KeyPress/KeyPress.ts
@@ -15,7 +15,10 @@ export const get = async (): Promise<KeyPressEvent> => {
     output: stdout,
     terminal: false,
   })
-  stdin.setRawMode(true)
+  const originalIsRawState = stdin.isRaw
+  if (!stdin.isRaw) {
+    stdin.setRawMode(true)
+  }
   Readline.emitKeypressEvents(stdin, rl)
 
   let listener: (...args: any[]) => void
@@ -24,6 +27,9 @@ export const get = async (): Promise<KeyPressEvent> => {
     listener = (k, e) => {
       rl.close()
       stdin.removeListener(`keypress`, listener)
+      if (!originalIsRawState) {
+        process.stdin.setRawMode(false)
+      }
       resolve(e)
     }
     stdin.on(`keypress`, listener)

--- a/packages/@molt/command/src/lib/KeyPress/index.ts
+++ b/packages/@molt/command/src/lib/KeyPress/index.ts
@@ -1,0 +1,1 @@
+export * as KeyPress from './KeyPress.js'

--- a/packages/@molt/command/src/parse/prompt.ts
+++ b/packages/@molt/command/src/parse/prompt.ts
@@ -139,7 +139,7 @@ namespace Inputs {
 
     let answer = false
     for await (const event of channels.readKeyPresses({
-      matching: [`left`, `right`, `space`, `return`, `y`, `n`],
+      matching: [`left`, `right`, `tab`, `return`, `y`, `n`],
     })) {
       if (event.name === `return`) {
         break
@@ -151,13 +151,12 @@ namespace Inputs {
         answer = false
       } else if (event.name === `right` || event.name === `y`) {
         answer = true
-      } else if (event.name === `space`) {
+      } else if (event.name === `tab`) {
         answer = !answer
       }
       channels.output(answer ? yes : no)
     }
     channels.output(ansiEscapes.cursorShow)
-    process.stdin.setRawMode(false) // TODO this should be called within `readKeyPresses` as part of some teardown
     return answer as any
   }
 
@@ -222,6 +221,7 @@ export const createMemoryPrompter = () => {
   })
   return {
     history: state.history,
+    script: state.script,
     answers: {
       add: (values: string[]) => {
         state.inputScript.push(...values)

--- a/packages/@molt/command/src/parse/prompt.ts
+++ b/packages/@molt/command/src/parse/prompt.ts
@@ -166,6 +166,7 @@ namespace Inputs {
   }
 
   export const number = async (params: { channels: Channels; prompt: string }) => {
+    params.channels.output(params.prompt)
     const answer_ = await params.channels.readLine()
     const answer = parseFloat(answer_)
     if (isNaN(answer)) return null

--- a/packages/@molt/command/src/parse/prompt.ts
+++ b/packages/@molt/command/src/parse/prompt.ts
@@ -1,5 +1,6 @@
 import { casesExhausted } from '../helpers.js'
 import { KeyPress } from '../lib/KeyPress/index.js'
+import { KeyPressEvent } from '../lib/KeyPress/KeyPress.js'
 import { Tex } from '../lib/Tex/index_.js'
 import { Text } from '../lib/Text/index.js'
 import { ParameterSpec } from '../ParameterSpec/index.js'
@@ -182,7 +183,7 @@ export const createMemoryPrompter = () => {
   const state: {
     inputScript: string[]
     script: {
-      keyPress: string[]
+      keyPress: KeyPress.KeyPressEvent<any>[]
     }
     history: {
       output: string[]
@@ -214,7 +215,7 @@ export const createMemoryPrompter = () => {
     },
     readKeyPresses: async function* (params) {
       for (const keyPress of state.script.keyPress) {
-        if (params.matching?.includes(keyPress as any) ?? true) {
+        if (params.matching?.includes(keyPress.name) ?? true) {
           yield await Promise.resolve(keyPress)
         }
       }
@@ -240,8 +241,7 @@ export const createStdioPrompter = () => {
     readKeyPresses: async function* (params) {
       for await (const event of KeyPress.watch()) {
         if (params.matching?.includes(event.name as any) ?? true) {
-          // console.log(keyStroke)
-          yield event
+          yield event as KeyPress.KeyPressEvent<any>
         }
       }
     },

--- a/packages/@molt/command/src/parse/prompt.ts
+++ b/packages/@molt/command/src/parse/prompt.ts
@@ -1,6 +1,5 @@
 import { casesExhausted } from '../helpers.js'
 import { KeyPress } from '../lib/KeyPress/index.js'
-import { KeyPressEvent } from '../lib/KeyPress/KeyPress.js'
 import { Tex } from '../lib/Tex/index_.js'
 import { Text } from '../lib/Text/index.js'
 import { ParameterSpec } from '../ParameterSpec/index.js'

--- a/packages/@molt/command/tests/prompt/__snapshots__/prompt.spec.ts.snap
+++ b/packages/@molt/command/tests/prompt/__snapshots__/prompt.spec.ts.snap
@@ -22,7 +22,8 @@ exports[`prompt when invalid input > args 1`] = `
 exports[`prompt when invalid input > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -32,7 +33,8 @@ exports[`prompt when invalid input > tty 1`] = `
 exports[`prompt when invalid input > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -49,7 +51,8 @@ exports[`prompt when invalid input OR missing input > args 1`] = `
 exports[`prompt when invalid input OR missing input > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -59,7 +62,8 @@ exports[`prompt when invalid input OR missing input > tty 1`] = `
 exports[`prompt when invalid input OR missing input > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -76,7 +80,8 @@ exports[`prompt when missing input > args 1`] = `
 exports[`prompt when missing input > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -86,7 +91,8 @@ exports[`prompt when missing input > tty 1`] = `
 exports[`prompt when missing input > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -103,7 +109,8 @@ exports[`prompt when omitted > args 1`] = `
 exports[`prompt when omitted > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -113,7 +120,8 @@ exports[`prompt when omitted > tty 1`] = `
 exports[`prompt when omitted > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",

--- a/packages/@molt/command/tests/prompt/__snapshots__/prompt.spec.ts.snap
+++ b/packages/@molt/command/tests/prompt/__snapshots__/prompt.spec.ts.snap
@@ -1,5 +1,177 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`boolean > can be toggled to "yes" > args 1`] = `
+{
+  "a": true,
+  "help": false,
+}
+`;
+
+exports[`boolean > can be toggled to "yes" > tty 1`] = `
+[
+  "[2m[90m1/1[39m[22m  [32ma[39m
+",
+  "[?25l",
+  "     ❯ ",
+  "[32m[1mno[22m[39m / yes",
+  "[1G",
+  "[2K",
+  "     ❯ ",
+  "no / [32m[1myes[22m[39m",
+  "[?25h",
+  "
+",
+]
+`;
+
+exports[`boolean > can be toggled to "yes" > tty strip ansi 1`] = `
+[
+  "1/1  a
+",
+  "",
+  "     ❯ ",
+  "no / yes",
+  "",
+  "",
+  "     ❯ ",
+  "no / yes",
+  "",
+  "
+",
+]
+`;
+
+exports[`boolean > can be toggled to "yes" and then back to "no" > args 1`] = `
+{
+  "a": false,
+  "help": false,
+}
+`;
+
+exports[`boolean > can be toggled to "yes" and then back to "no" > tty 1`] = `
+[
+  "[2m[90m1/1[39m[22m  [32ma[39m
+",
+  "[?25l",
+  "     ❯ ",
+  "[32m[1mno[22m[39m / yes",
+  "[1G",
+  "[2K",
+  "     ❯ ",
+  "no / [32m[1myes[22m[39m",
+  "[1G",
+  "[2K",
+  "     ❯ ",
+  "[32m[1mno[22m[39m / yes",
+  "[?25h",
+  "
+",
+]
+`;
+
+exports[`boolean > can be toggled to "yes" and then back to "no" > tty strip ansi 1`] = `
+[
+  "1/1  a
+",
+  "",
+  "     ❯ ",
+  "no / yes",
+  "",
+  "",
+  "     ❯ ",
+  "no / yes",
+  "",
+  "",
+  "     ❯ ",
+  "no / yes",
+  "",
+  "
+",
+]
+`;
+
+exports[`boolean > can use tab to toggle between "yes" and "no" > args 1`] = `
+{
+  "a": false,
+  "help": false,
+}
+`;
+
+exports[`boolean > can use tab to toggle between "yes" and "no" > tty 1`] = `
+[
+  "[2m[90m1/1[39m[22m  [32ma[39m
+",
+  "[?25l",
+  "     ❯ ",
+  "[32m[1mno[22m[39m / yes",
+  "[1G",
+  "[2K",
+  "     ❯ ",
+  "no / [32m[1myes[22m[39m",
+  "[1G",
+  "[2K",
+  "     ❯ ",
+  "[32m[1mno[22m[39m / yes",
+  "[?25h",
+  "
+",
+]
+`;
+
+exports[`boolean > can use tab to toggle between "yes" and "no" > tty strip ansi 1`] = `
+[
+  "1/1  a
+",
+  "",
+  "     ❯ ",
+  "no / yes",
+  "",
+  "",
+  "     ❯ ",
+  "no / yes",
+  "",
+  "",
+  "     ❯ ",
+  "no / yes",
+  "",
+  "
+",
+]
+`;
+
+exports[`boolean > defaults to "no" > args 1`] = `
+{
+  "a": false,
+  "help": false,
+}
+`;
+
+exports[`boolean > defaults to "no" > tty 1`] = `
+[
+  "[2m[90m1/1[39m[22m  [32ma[39m
+",
+  "[?25l",
+  "     ❯ ",
+  "[32m[1mno[22m[39m / yes",
+  "[?25h",
+  "
+",
+]
+`;
+
+exports[`boolean > defaults to "no" > tty strip ansi 1`] = `
+[
+  "1/1  a
+",
+  "",
+  "     ❯ ",
+  "no / yes",
+  "",
+  "
+",
+]
+`;
+
 exports[`can be explicitly disabled > args 1`] = `[ErrorMissingArgument: Missing argument for flag "a".]`;
 
 exports[`can be explicitly disabled > tty 1`] = `[]`;

--- a/packages/@molt/command/tests/prompt/__snapshots__/settings.spec.ts.snap
+++ b/packages/@molt/command/tests/prompt/__snapshots__/settings.spec.ts.snap
@@ -10,7 +10,8 @@ exports[`can be stack of conditional prompts > args 1`] = `
 exports[`can be stack of conditional prompts > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -20,7 +21,8 @@ exports[`can be stack of conditional prompts > tty 1`] = `
 exports[`can be stack of conditional prompts > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -37,7 +39,8 @@ exports[`command level > passing object makes enabled default to true > args 1`]
 exports[`command level > passing object makes enabled default to true > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -47,7 +50,8 @@ exports[`command level > passing object makes enabled default to true > tty 1`] 
 exports[`command level > passing object makes enabled default to true > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -64,7 +68,8 @@ exports[`parameter defaults to custom settings > args 1`] = `
 exports[`parameter defaults to custom settings > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -74,7 +79,8 @@ exports[`parameter defaults to custom settings > tty 1`] = `
 exports[`parameter defaults to custom settings > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -91,7 +97,8 @@ exports[`parameter level > can be passed object > args 1`] = `
 exports[`parameter level > can be passed object > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -101,7 +108,8 @@ exports[`parameter level > can be passed object > tty 1`] = `
 exports[`parameter level > can be passed object > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -124,7 +132,8 @@ exports[`prompt can be enabled by default > args 1`] = `
 exports[`prompt can be enabled by default > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -134,7 +143,8 @@ exports[`prompt can be enabled by default > tty 1`] = `
 exports[`prompt can be enabled by default > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -151,7 +161,8 @@ exports[`prompt can be toggled by check on error > toggle to enabled > check doe
 exports[`prompt can be toggled by check on error > toggle to enabled > check does match > tty 1`] = `
 [
   "[2m[90m1/1[39m[22m  [32ma[39m
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",
@@ -161,7 +172,8 @@ exports[`prompt can be toggled by check on error > toggle to enabled > check doe
 exports[`prompt can be toggled by check on error > toggle to enabled > check does match > tty strip ansi 1`] = `
 [
   "1/1  a
-     ❯ ",
+",
+  "     ❯ ",
   "foo",
   "
 ",

--- a/packages/@molt/command/tests/prompt/prompt.spec.ts
+++ b/packages/@molt/command/tests/prompt/prompt.spec.ts
@@ -1,18 +1,61 @@
 import type { ParameterConfiguration } from '../../src/Builder/root/types.js'
 import type { Settings } from '../../src/entrypoints/types.js'
 import { Command } from '../../src/index.js'
-import { l1, s, tryCatch } from '../_/helpers.js'
+import type { KeyPress } from '../../src/lib/KeyPress/index.js'
+import { b, l1, s, tryCatch } from '../_/helpers.js'
 import { memoryPrompter } from '../_/mocks/tty.js'
 import stripAnsi from 'strip-ansi'
 import { expectType } from 'tsd'
-import { expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 // TODO test that prompt order is based on order of parameter definition
 
 let parameters: Record<string, ParameterConfiguration>
 let answers: string[]
+let keyPresses: KeyPress.KeyPressEvent[]
 let line: string[]
 const settings: Settings.Input = {}
+
+beforeEach(() => {
+  parameters = {}
+  answers = []
+  keyPresses = []
+  line = []
+})
+
+describe(`boolean`, () => {
+  it(`defaults to "no"`, async () => {
+    parameters = { a: { schema: b, prompt: true } }
+    keyPresses.push({ ctrl: false, meta: false, sequence: ``, shift: false, name: `return` })
+    await run()
+  })
+  it(`can be toggled to "yes"`, async () => {
+    parameters = { a: { schema: b, prompt: true } }
+    keyPresses.push(
+      { ctrl: false, meta: false, sequence: ``, shift: false, name: `right` },
+      { ctrl: false, meta: false, sequence: ``, shift: false, name: `return` },
+    )
+    await run()
+  })
+  it(`can be toggled to "yes" and then back to "no"`, async () => {
+    parameters = { a: { schema: b, prompt: true } }
+    keyPresses.push(
+      { ctrl: false, meta: false, sequence: ``, shift: false, name: `right` },
+      { ctrl: false, meta: false, sequence: ``, shift: false, name: `left` },
+      { ctrl: false, meta: false, sequence: ``, shift: false, name: `return` },
+    )
+    await run()
+  })
+  it(`can use tab to toggle between "yes" and "no"`, async () => {
+    parameters = { a: { schema: b, prompt: true } }
+    keyPresses.push(
+      { ctrl: false, meta: false, sequence: ``, shift: false, name: `tab` },
+      { ctrl: false, meta: false, sequence: ``, shift: false, name: `tab` },
+      { ctrl: false, meta: false, sequence: ``, shift: false, name: `return` },
+    )
+    await run()
+  })
+})
 
 it(`can be explicitly disabled`, async () => {
   parameters = {
@@ -197,6 +240,7 @@ it(`Static type tests`, () => {
 
 const run = async () => {
   memoryPrompter.answers.add(answers)
+  memoryPrompter.script.keyPress.push(...keyPresses)
   // eslint-disable-next-line
   const args = await tryCatch(async () => {
     // eslint-disable-next-line

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       alge:
         specifier: 0.8.1
         version: 0.8.1
+      ansi-escapes:
+        specifier: ^6.2.0
+        version: 6.2.0
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
@@ -1045,6 +1048,13 @@ packages:
     dependencies:
       type-fest: 0.21.3
     dev: true
+
+  /ansi-escapes@6.2.0:
+    resolution: {integrity: sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      type-fest: 3.13.1
+    dev: false
 
   /ansi-red@0.1.1:
     resolution: {integrity: sha512-ewaIr5y+9CUTGFwZfpECUbFlGcC0GCw1oqR9RI6h1gQCd9Aj2GxSckCnPsVJnmfMZbwFYE+leZGASgkWl06Jow==}
@@ -3112,6 +3122,11 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
     dev: true
+
+  /type-fest@3.13.1:
+    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
+    engines: {node: '>=14.16'}
+    dev: false
 
   /type-fest@4.3.1:
     resolution: {integrity: sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==}


### PR DESCRIPTION
Progresses #9 

This PR brings improved interactivity around prompt for booleans.

It now has special UI and keyboard support.

- Tab key toggles
- 'y' selects yes
- right selects yes
- 'n' selects no
- left selects no
- defaults to no

#### TASKS

- [x] Out of band docs (website, README, ...)
- [ ] In of band docs (jsdoc)
- [x] Tests
