### PR TITLE
refactor(@molt/command): effect streams instead of async iterable

### DIFF
--- a/packages/@molt/command/src/lib/KeyPress/KeyPress.ts
+++ b/packages/@molt/command/src/lib/KeyPress/KeyPress.ts
@@ -1,3 +1,4 @@
+import { Exit, pipe, Stream } from 'effect'
 import { Effect } from 'effect'
 import { stdin, stdout } from 'node:process'
 import * as Readline from 'node:readline'
@@ -46,7 +47,7 @@ export interface KeyPressEvent<Name extends Key = Key> {
   sequence: string
 }
 
-export const get = Effect.async<never, never, KeyPressEvent>((resume) => {
+export const awaitKeyPress = Effect.async<never, never, KeyPressEvent>((resume) => {
   const rl = Readline.promises.createInterface({
     input: stdin,
     output: stdout,
@@ -69,19 +70,15 @@ export const get = Effect.async<never, never, KeyPressEvent>((resume) => {
   stdin.on(`keypress`, listener)
 })
 
-export const watch = (): AsyncIterable<KeyPressEvent> => {
-  return {
-    [Symbol.asyncIterator]: () => ({
-      next: async () => {
-        const event = await Effect.runPromise(get)
-        if (event.name == `c` && event.ctrl == true) {
-          process.exit()
-        }
-        return {
-          value: event,
-          done: false,
-        }
-      },
+export const stream = (params?: {
+  exitOnCtrlC?: boolean
+}): Stream.Stream<never, never, KeyPressEvent<any> | Exit.Exit<never, void>> =>
+  pipe(
+    Stream.repeatEffect(awaitKeyPress),
+    Stream.map((event) =>
+      event.name == `c` && event.ctrl == true && params?.exitOnCtrlC !== false ? Exit.unit : event,
+    ),
+    Stream.takeUntil((event) => {
+      return Exit.isExit(event)
     }),
-  }
-}
+  )

--- a/packages/@molt/command/src/lib/KeyPress/KeyPress.ts
+++ b/packages/@molt/command/src/lib/KeyPress/KeyPress.ts
@@ -47,7 +47,7 @@ export interface KeyPressEvent<Name extends Key = Key> {
   sequence: string
 }
 
-export const awaitKeyPress = Effect.async<never, never, KeyPressEvent>((resume) => {
+export const readOne = Effect.async<never, never, KeyPressEvent>((resume) => {
   const rl = Readline.promises.createInterface({
     input: stdin,
     output: stdout,
@@ -70,11 +70,9 @@ export const awaitKeyPress = Effect.async<never, never, KeyPressEvent>((resume) 
   stdin.on(`keypress`, listener)
 })
 
-export const stream = (params?: {
-  exitOnCtrlC?: boolean
-}): Stream.Stream<never, never, KeyPressEvent<any> | Exit.Exit<never, void>> =>
+export const readMany = (params?: { exitOnCtrlC?: boolean }) =>
   pipe(
-    Stream.repeatEffect(awaitKeyPress),
+    Stream.repeatEffect(readOne),
     Stream.map((event) =>
       event.name == `c` && event.ctrl == true && params?.exitOnCtrlC !== false ? Exit.unit : event,
     ),

--- a/packages/@molt/command/src/lib/PromptEngine/PromptEngine.ts
+++ b/packages/@molt/command/src/lib/PromptEngine/PromptEngine.ts
@@ -1,6 +1,7 @@
 import type { KeyPress } from '../KeyPress/index.js'
 import { Text } from '../Text/index.js'
 import ansiEscapes from 'ansi-escapes'
+import { Effect, Exit, pipe, Stream } from 'effect'
 
 interface KeyPressPattern {
   name?: KeyPress.Key
@@ -39,7 +40,6 @@ export namespace PromptEngine {
 
   export const create = <State extends object, Skippable extends boolean>(input: Input<State, Skippable>) => {
     return async (): Promise<Skippable extends true ? null | State : State> => {
-      let state = input.initialState
       const matchers = (input?.on ?? []).map(({ match, run }) => {
         return {
           match: (Array.isArray(match) ? match : [match]).map((_) =>
@@ -60,7 +60,7 @@ export namespace PromptEngine {
         process.off(`exit`, cleanup)
       }
       let previousLineCount = 0
-      const refresh = () => {
+      const refresh = (state: State) => {
         channels.output(ansiEscapes.eraseLines(previousLineCount))
         channels.output(ansiEscapes.cursorTo(0))
         const content = input.draw(state)
@@ -71,33 +71,36 @@ export namespace PromptEngine {
       channels.output(ansiEscapes.cursorHide)
       process.once(`exit`, cleanup)
 
-      refresh()
+      const initialState = input.initialState
+      refresh(initialState)
 
-      for await (const event of channels.readKeyPresses()) {
-        if (input.skippable && event.name === `escape`) {
-          cleanup()
-          // @ts-expect-error ignoreme
-          return null
-        }
+      const result = await pipe(
+        channels.readKeyPresses(),
+        Stream.takeUntil(
+          (value) => !Exit.isExit(value) && input.skippable === true && value.name === `escape`,
+        ),
+        Stream.takeUntil((value) => !Exit.isExit(value) && value.name === `return`),
+        Stream.runFold(initialState as State | null, (state, value): State | null => {
+          // todo do higher in the stack
+          if (Exit.isExit(value)) {
+            process.exit()
+          }
+          if (state === null) return null
+          if (input.skippable && value.name === `escape`) return null
+          if (value.name === `return`) return state
+          const matcher = matchers.find((matcher) =>
+            matcher.match.some((match) => isKeyPressMatchPattern(value, match ?? {})),
+          )
+          const newState = matcher?.run(state, value) ?? state
+          refresh(newState)
+          return newState
+        }),
+        Effect.runPromise,
+      )
 
-        if (event.name === `return`) {
-          cleanup()
-          // @ts-expect-error ignoreme
-          return state
-        }
+      cleanup()
 
-        // prettier-ignore
-        const matcher = matchers.find((matcher) => matcher.match.some((match) => isKeyPressMatchPattern(event, match ?? {})))
-        if (matcher) {
-          const newState = matcher.run(state, event)
-          state = newState
-        }
-        refresh()
-      }
-
-      // @ts-expect-error ignoreme
-      // This is unreachable because the key presses iterator will never end, but TypeScript doesn't know that.
-      return null
+      return result as Skippable extends true ? null | State : State
     }
   }
 
@@ -106,6 +109,6 @@ export namespace PromptEngine {
     readLine: () => Promise<string>
     readKeyPresses: <K extends KeyPress.Key>(params?: {
       matching?: K[]
-    }) => AsyncIterable<KeyPress.KeyPressEvent<K>>
+    }) => Stream.Stream<never, never, Exit.Exit<never, void> | KeyPress.KeyPressEvent<K>>
   }
 }

--- a/packages/@molt/command/src/lib/PromptEngine/PromptEngine.ts
+++ b/packages/@molt/command/src/lib/PromptEngine/PromptEngine.ts
@@ -107,8 +107,11 @@ export namespace PromptEngine {
   export interface Channels {
     output: (value: string) => void
     readLine: () => Promise<string>
-    readKeyPresses: <K extends KeyPress.Key>(params?: {
-      matching?: K[]
-    }) => Stream.Stream<never, never, Exit.Exit<never, void> | KeyPress.KeyPressEvent<K>>
+    readKeyPresses: <K extends KeyPress.Key>(
+      params?: ReadKeyPressesParams<K>,
+    ) => Stream.Stream<never, never, Exit.Exit<never, void> | KeyPress.KeyPressEvent<K>>
+  }
+  export interface ReadKeyPressesParams<K extends string> {
+    matching?: K[]
   }
 }

--- a/packages/@molt/command/src/parse/prompt.ts
+++ b/packages/@molt/command/src/parse/prompt.ts
@@ -8,6 +8,7 @@ import { Text } from '../lib/Text/index.js'
 import { Term } from '../term.js'
 import type { ParseProgressPostPrompt, ParseProgressPostPromptAnnotation } from './parse.js'
 import chalk from 'chalk'
+import { Exit, Stream } from 'effect'
 import * as Readline from 'node:readline'
 
 /**
@@ -387,13 +388,12 @@ export const createMemoryPrompter = () => {
       state.history.all.push(value)
       return Promise.resolve(value)
     },
-    readKeyPresses: async function* (params) {
-      for (const keyPress of state.script.keyPress) {
-        if (params?.matching?.includes(keyPress.name) ?? true) {
-          yield await Promise.resolve(keyPress)
-        }
-      }
-    },
+    readKeyPresses: (params) =>
+      Stream.fromIterable(state.script.keyPress).pipe(
+        Stream.filter((event) => {
+          return params?.matching?.includes(event.name) ?? true
+        }),
+      ),
   })
   return {
     history: state.history,
@@ -413,13 +413,13 @@ export type MemoryPrompter = ReturnType<typeof createMemoryPrompter>
 export const createStdioPrompter = () => {
   return createPrompter({
     output: (value) => process.stdout.write(value),
-    readKeyPresses: async function* (params) {
-      for await (const event of KeyPress.watch()) {
-        if (params?.matching?.includes(event.name as any) ?? true) {
-          yield event as KeyPress.KeyPressEvent<any>
-        }
-      }
-    },
+    readKeyPresses: (params) =>
+      KeyPress.stream().pipe(
+        Stream.filter((event) => {
+          if (Exit.isExit(event)) return true
+          return params?.matching?.includes(event.name) ?? true
+        }),
+      ),
     readLine: () => {
       return new Promise((res) => {
         const lineReader = Readline.createInterface({

--- a/packages/@molt/command/src/parse/prompt.ts
+++ b/packages/@molt/command/src/parse/prompt.ts
@@ -1,6 +1,7 @@
 import { CommandParameter } from '../CommandParameter/index.js'
 import { casesExhausted } from '../helpers.js'
 import { KeyPress } from '../lib/KeyPress/index.js'
+import type { KeyPressEvent } from '../lib/KeyPress/KeyPress.js'
 import type { Pam } from '../lib/Pam/index.js'
 import { PromptEngine } from '../lib/PromptEngine/PromptEngine.js'
 import { Tex } from '../lib/Tex/index_.js'
@@ -413,11 +414,11 @@ export type MemoryPrompter = ReturnType<typeof createMemoryPrompter>
 export const createStdioPrompter = () => {
   return createPrompter({
     output: (value) => process.stdout.write(value),
-    readKeyPresses: (params) =>
-      KeyPress.stream().pipe(
-        Stream.filter((event) => {
+    readKeyPresses: <K extends KeyPress.Key>(params?: PromptEngine.ReadKeyPressesParams<K>) =>
+      KeyPress.readMany().pipe(
+        Stream.filter((event): event is Exit.Exit<never, void> | KeyPressEvent<K> => {
           if (Exit.isExit(event)) return true
-          return params?.matching?.includes(event.name) ?? true
+          return params?.matching?.includes(event.name as any) ?? true
         }),
       ),
     readLine: () => {


### PR DESCRIPTION
closes #...

#### TASKS

- [ ] Out of band docs (website, README, ...)
- [ ] In of band docs (jsdoc)
- [ ] Tests
