### PR TITLE
refactor(@molt/types): unify check pred and msg

### DIFF
--- a/packages/@molt/types/src/Name/checks.ts
+++ b/packages/@molt/types/src/Name/checks.ts
@@ -1,0 +1,94 @@
+import type { Strings } from '../prelude.js'
+import type { Name } from './data.js'
+import type { SomeLimits } from './parser.js'
+
+// prettier-ignore
+export namespace Messages {
+	export type WithHeader<Body extends string> = `Error(s):\n${Body}`
+  export type LongTooShort<Variant extends string> = `A long flag must be two (2) or more characters but you have: '--${Variant}'.`
+	export type AliasDuplicate<Variant extends string> =`Your alias "${Variant}" is a duplicate.`
+	export type ShortTooLong<Variant extends string> = `A short flag must be exactly one (1) character but you have: '-${Variant}'.`
+	export type AlreadyTaken<Variant extends string> = `The name "${Variant}" cannot be used because it is already used for another flag.`
+	export type Reserved<Variant extends string> = `The name "${Variant}" cannot be used because it is reserved.`
+}
+
+// prettier-ignore
+export namespace Kinds {
+	export type LongTooShort<Variant extends string> = {
+		predicate: Strings.Length<Variant> extends 1 ? true : false
+		message: Messages.LongTooShort<Variant>
+	}
+
+	export type ShortTooLong<Variant extends string> = {
+		predicate: Strings.Length<Variant> extends 1 ? false : true
+		message: Messages.ShortTooLong<Variant>
+	}
+
+	export type AliasDuplicate<$Name extends Name, Variant extends string> = {
+		predicate: Strings.KebabToCamelCase<Variant> extends $Name['long'] | $Name['short'] ? true : false
+		message: Messages.AliasDuplicate<Variant>
+	}
+		
+	export type AlreadyTaken<Limits extends SomeLimits, Variant extends string> = {
+		predicate:	Limits['usedNames'] extends undefined 																											     							? false :
+								Strings.KebabToCamelCase<Variant> extends Strings.KebabToCamelCase<Exclude<Limits['usedNames'], undefined>> 	? true :
+																																																		   													false
+		message: Messages.AlreadyTaken<Variant>
+	}
+
+	export type Reserved<Limits extends SomeLimits, Variant extends string> = {
+		predicate:	Limits['reservedNames'] extends undefined 																																				? false :
+								Strings.KebabToCamelCase<Variant> extends Strings.KebabToCamelCase<Exclude<Limits['reservedNames'], undefined>> 	? true :
+																																																																		false
+		message: Messages.Reserved<Variant>
+	}
+}
+
+export type BaseChecks<
+  Variant extends string,
+  limits extends SomeLimits,
+  $FlagName extends Name,
+> = FilterFailures<
+  [
+    Kinds.AliasDuplicate<$FlagName, Variant>,
+    Kinds.AlreadyTaken<limits, Variant>,
+    Kinds.Reserved<limits, Variant>,
+  ]
+>
+
+export type LongChecks<
+  Variant extends string,
+  limits extends SomeLimits,
+  $FlagName extends Name,
+> = FilterFailures<[...BaseChecks<Variant, limits, $FlagName>, Kinds.LongTooShort<Variant>]>
+
+export type ShortChecks<
+  Variant extends string,
+  limits extends SomeLimits,
+  $FlagName extends Name,
+> = FilterFailures<[...BaseChecks<Variant, limits, $FlagName>, Kinds.ShortTooLong<Variant>]>
+
+export interface Result {
+  predicate: boolean
+  message: string
+}
+
+export type SomeFailures = [Result, ...Result[]]
+
+// prettier-ignore
+export type ReportFailures<Results extends [...Result[]], Accumulator extends string = ''> =
+	Results extends [infer Head extends Result, ...infer Tail extends Result[]]
+		? Head['predicate'] extends true
+			? Accumulator extends ''
+				? ReportFailures<Tail, Messages.WithHeader<Head['message']>>
+				: ReportFailures<Tail, `${Accumulator}\n${Head['message']}`>
+			: ReportFailures<Tail, Accumulator>
+		: Accumulator
+
+// prettier-ignore
+type FilterFailures<Results extends [...Result[]], Accumulator extends Result[] = []> =
+	Results extends [infer Head extends Result, ...infer Tail extends Result[]]
+		? Head['predicate'] extends true
+			? FilterFailures<Tail, [...Accumulator, Head]>
+			: FilterFailures<Tail, Accumulator>
+		: Accumulator

--- a/packages/@molt/types/src/Name/index.ts
+++ b/packages/@molt/types/src/Name/index.ts
@@ -1,2 +1,3 @@
+export * as Checks from './checks.js'
 export * as Data from './data.js'
-export { Checks, Errors, Parse } from './parser.js'
+export { Errors, Parse } from './parser.js'

--- a/packages/@molt/types/src/Name/parser.ts
+++ b/packages/@molt/types/src/Name/parser.ts
@@ -1,57 +1,13 @@
 import type { Strings } from '../prelude.js'
+import type { BaseChecks, LongChecks, ReportFailures, ShortChecks, SomeFailures } from './checks.js'
 import type { Name, NameEmpty } from './data.js'
 
 // prettier-ignore
-export namespace Checks {
-	export type LongTooShort<Variant extends string> =
-		Strings.Length<Variant> extends 1 ? true : false
-
-	export type ShortTooLong<Variant extends string> =
-		Strings.Length<Variant> extends 1 ? false : true
-
-	export type AliasDuplicate<$Name extends Name, Variant extends string> =
-		Strings.KebabToCamelCase<Variant> extends $Name['long'] | $Name['short'] ? true : false
-
-	export type AlreadyTaken<Limits extends SomeLimits, Name extends string> =
-		Limits['usedNames'] extends undefined 																											     					? false :
-		Strings.KebabToCamelCase<Name> extends Strings.KebabToCamelCase<Exclude<Limits['usedNames'], undefined>> 	? true :
-																																																		   					false
-	export type Reserved<Limits extends SomeLimits, Name extends string> =
-		Limits['reservedNames'] extends undefined 																																		? false :
-		Strings.KebabToCamelCase<Name> extends Strings.KebabToCamelCase<Exclude<Limits['reservedNames'], undefined>> 	? true :
-																																																										false
-}
-
-// prettier-ignore
 export namespace Errors {
-	export type LongTooShort<Given extends string> = `Error: A long flag must be two (2) or more characters but you have: '--${Given}'.`
-	export type ShortTooLong<Given extends string> = `Error: A short flag must be exactly one (1) character but you have: '-${Given}'.`
 	export type TrailingPipe = `Error: You have a trailing pipe. Pipes are for adding aliases. Add more names after your pipe or remove it.`
 	export type Empty = `Error: You must specify at least one name for your flag.`
 	export type Unknown = `Error: Cannot parse your flag expression.`
-	export type AliasDuplicate<Variant extends string> = `Error: Your alias "${Variant}" is a duplicate.`
-	export type AlreadyTaken<Variant extends string> = `Error: The name "${Variant}" cannot be used because it is already used for another flag.` 
-	export type Reserved<Variant extends string> = `Error: The name "${Variant}" cannot be used because it is reserved.`
 }
-
-// prettier-ignore
-export type BaseFlagNameChecks<Variant extends string, limits extends SomeLimits, $FlagName extends Name> = 
-	Checks.AliasDuplicate<$FlagName, Variant>	extends true 	? Errors.AliasDuplicate<Variant> :
-	Checks.AlreadyTaken<limits, Variant> extends true 			? Errors.AlreadyTaken<Variant> :
-	Checks.Reserved<limits, Variant> extends true 					? Errors.Reserved<Variant> :
-																														null
-
-// prettier-ignore
-export type DashPrefixedLongFlagNameChecks<Variant extends string, limits extends SomeLimits, $FlagName extends Name> = 
-	BaseFlagNameChecks<Variant, limits, $FlagName> extends string 		? BaseFlagNameChecks<Variant, limits, $FlagName> :
-	Checks.LongTooShort<Variant> extends true 												? Errors.LongTooShort<Variant> :
-																																			null
-
-// prettier-ignore
-export type DashPrefixedShortFlagNameChecks<Variant extends string, limits extends SomeLimits, $FlagName extends Name> = 
-	BaseFlagNameChecks<Variant, limits, $FlagName> extends string 	? BaseFlagNameChecks<Variant, limits, $FlagName> :
-	Checks.ShortTooLong<Variant> extends true 											? Errors.ShortTooLong<Variant> :
-																																		null
 
 // prettier-ignore
 type AddAliasLong<$FlagName extends Name, Variant extends string> = Omit<$FlagName, 'aliases'> & { aliases: { long: [...$FlagName['aliases']['long'], Strings.KebabToCamelCase<Variant>], short: $FlagName['aliases']['short'] }}
@@ -62,12 +18,12 @@ type AddLong<$FlagName extends Name, Variant extends string> = Omit<$FlagName, '
 // prettier-ignore
 type AddShort<$FlagName extends Name, Variant extends string> = Omit<$FlagName, 'short'> & { short: Variant  }
 
-type SomeLimits = {
+export interface SomeLimits {
   reservedNames: string | undefined
   usedNames: string | undefined
 }
 
-type SomeLimitsNone = {
+interface SomeLimitsNone {
   reservedNames: undefined
   usedNames: undefined
 }
@@ -88,34 +44,29 @@ type _Parse<E extends string, Limits extends SomeLimits, $FlagName extends Name>
 	E extends `${infer initial} `                        	? _Parse<initial, Limits, $FlagName> :
 
 	// Capture a long flag & continue
-	E extends `--${infer v} ${infer tail}`            	? DashPrefixedLongFlagNameChecks<v, Limits, $FlagName> extends string ?
-																												 	DashPrefixedLongFlagNameChecks<v, Limits, $FlagName> :
+	E extends `--${infer v} ${infer tail}`            	? LongChecks<v, Limits, $FlagName> extends SomeFailures ? ReportFailures<LongChecks<v, Limits, $FlagName>> :
 																												 	$FlagName['long'] extends undefined ?
 																												 		_Parse<tail, Limits, AddLong<$FlagName, v>> :
 																												 	 	_Parse<tail, Limits, AddAliasLong<$FlagName, v>> :
 	// Capture a long name & Done!
-	E extends `--${infer v}` 							          	? DashPrefixedLongFlagNameChecks<v, Limits, $FlagName> extends string ?
-																														DashPrefixedLongFlagNameChecks<v, Limits, $FlagName> :
+	E extends `--${infer v}` 							          	? LongChecks<v, Limits, $FlagName> extends SomeFailures ? ReportFailures<LongChecks<v, Limits, $FlagName>> :
 																														$FlagName['long'] extends undefined ?
 																															AddLong<$FlagName, v> :
 																															AddAliasLong<$FlagName, v> :
 
 	// Capture a short flag & continue
-	E extends `-${infer v} ${infer tail}`            	? DashPrefixedShortFlagNameChecks<v, Limits, $FlagName> extends string ?
-																														DashPrefixedShortFlagNameChecks<v, Limits, $FlagName> :
+	E extends `-${infer v} ${infer tail}`            	? ShortChecks<v, Limits, $FlagName> extends SomeFailures ? ReportFailures<ShortChecks<v, Limits, $FlagName>> :
 																														$FlagName['short'] extends undefined ?
 																															_Parse<tail, Limits, AddShort<$FlagName, v>> :
 																															_Parse<tail, Limits, AddAliasShort<$FlagName, v>> :
 	// Capture a short name & Done!
-	E extends `-${infer v}` 							            	? DashPrefixedShortFlagNameChecks<v, Limits, $FlagName> extends string ?
-																														DashPrefixedShortFlagNameChecks<v, Limits, $FlagName> :
+	E extends `-${infer v}` 							            	? ShortChecks<v, Limits, $FlagName> extends SomeFailures ? ReportFailures<ShortChecks<v, Limits, $FlagName>> :
 																														$FlagName['short'] extends undefined ?
 																															AddShort<$FlagName, v> :
 																															AddAliasShort<$FlagName, v> :
 
 	// Capture a long flag & continue
-	E extends `${infer v} ${infer tail}`             	? BaseFlagNameChecks<v, Limits, $FlagName> extends string ?
-																														DashPrefixedLongFlagNameChecks<v, Limits, $FlagName> :
+	E extends `${infer v} ${infer tail}`             	? BaseChecks<v, Limits, $FlagName> extends SomeFailures ? ReportFailures<BaseChecks<v, Limits, $FlagName>> :
 																														Strings.Length<v> extends 1 ?
 																															$FlagName['short'] extends undefined ?
 																																_Parse<tail, Limits, AddShort<$FlagName, v>> :
@@ -125,8 +76,7 @@ type _Parse<E extends string, Limits extends SomeLimits, $FlagName extends Name>
 																																_Parse<tail, Limits, AddAliasLong<$FlagName, v>> :
 
 	// Capture a short name & Done!
-  E extends `${infer v}`                           	? BaseFlagNameChecks<v, Limits, $FlagName> extends string ?
-																														DashPrefixedShortFlagNameChecks<v, Limits, $FlagName> :
+  E extends `${infer v}`                           	? BaseChecks<v, Limits, $FlagName> extends SomeFailures ? ReportFailures<BaseChecks<v, Limits, $FlagName>> :
 																														Strings.Length<v> extends 1 ?
 																															$FlagName['short'] extends undefined ?
 																																AddShort<$FlagName, v> :

--- a/packages/@molt/types/tests/index.spec.ts
+++ b/packages/@molt/types/tests/index.spec.ts
@@ -11,51 +11,51 @@ namespace _testErrors {
 	expectType<Name.Errors.Empty>(as<											Name.Parse<' '>>())
 
 	// Short Flag
-	expectType<Name.Errors.Reserved<'a'>>(as<					Name.Parse<'-a', { reservedNames: 'a'; usedNames: undefined }>>())
+	expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'a'>>>(as<					Name.Parse<'-a', { reservedNames: 'a'; usedNames: undefined }>>())
 	// Long Flag
-	expectType<Name.Errors.Reserved<'abc'>>(as<				Name.Parse<'--abc', { reservedNames: 'abc'; usedNames: undefined }>>())
+	expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'abc'>>>(as<				Name.Parse<'--abc', { reservedNames: 'abc'; usedNames: undefined }>>())
 		// Mixing dash prefix style and kebab/camel case does not matter
-		expectType<Name.Errors.Reserved<'foo-bar'>>(as<		Name.Parse<'--foo-bar', { reservedNames: 'fooBar';  usedNames: undefined }>>())
-		expectType<Name.Errors.Reserved<'fooBar'>>(as<		Name.Parse<'--fooBar',  { reservedNames: 'foo-bar'; usedNames: undefined }>>())
-		expectType<Name.Errors.Reserved<'foo-bar'>>(as<		Name.Parse<'foo-bar',   { reservedNames: 'fooBar';  usedNames: undefined }>>())
-		expectType<Name.Errors.Reserved<'fooBar'>>(as<		Name.Parse<'fooBar',    { reservedNames: 'foo-bar'; usedNames: undefined }>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'foo-bar'>>>(as<		Name.Parse<'--foo-bar', { reservedNames: 'fooBar';  usedNames: undefined }>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'fooBar'>>>(as<		Name.Parse<'--fooBar',  { reservedNames: 'foo-bar'; usedNames: undefined }>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'foo-bar'>>>(as<		Name.Parse<'foo-bar',   { reservedNames: 'fooBar';  usedNames: undefined }>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'fooBar'>>>(as<		Name.Parse<'fooBar',    { reservedNames: 'foo-bar'; usedNames: undefined }>>())
 			// Aliases
-			expectType<Name.Errors.Reserved<'foo-bar'>>(as<		Name.Parse<'--foo --foo-bar', { reservedNames: 'fooBar';  usedNames: undefined }>>())
-			expectType<Name.Errors.Reserved<'fooBar'>>(as<		Name.Parse<'--foo --fooBar',  { reservedNames: 'foo-bar'; usedNames: undefined }>>())
-			expectType<Name.Errors.Reserved<'foo-bar'>>(as<		Name.Parse<'foo foo-bar',   { reservedNames: 'fooBar';  usedNames: undefined }>>())
-			expectType<Name.Errors.Reserved<'fooBar'>>(as<		Name.Parse<'foo fooBar',    { reservedNames: 'foo-bar'; usedNames: undefined }>>())
+			expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'foo-bar'>>>(as<		Name.Parse<'--foo --foo-bar', { reservedNames: 'fooBar';  usedNames: undefined }>>())
+			expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'fooBar'>>>(as<		Name.Parse<'--foo --fooBar',  { reservedNames: 'foo-bar'; usedNames: undefined }>>())
+			expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'foo-bar'>>>(as<		Name.Parse<'foo foo-bar',   { reservedNames: 'fooBar';  usedNames: undefined }>>())
+			expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.Reserved<'fooBar'>>>(as<		Name.Parse<'foo fooBar',    { reservedNames: 'foo-bar'; usedNames: undefined }>>())
 
 	// Short Flag
-	expectType<Name.Errors.AlreadyTaken<'a'>>(as<			Name.Parse<'-a', { usedNames: 'a'; reservedNames: undefined }>>())
+	expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AlreadyTaken<'a'>>>(as<			Name.Parse<'-a', { usedNames: 'a'; reservedNames: undefined }>>())
 	// Long Flag
-		expectType<Name.Errors.AlreadyTaken<'abc'>>(as<		Name.Parse<'--abc', { usedNames: 'abc'; reservedNames: undefined }>>())
+		expectType<"Error(s):\nThe name \"abc\" cannot be used because it is already used for another flag.">(as<		Name.Parse<'--abc', { usedNames: 'abc'; reservedNames: undefined }>>())
 		// Mixing dash prefix style and kebab/camel case does not matter
-		expectType<Name.Errors.AlreadyTaken<'fooBar'>>(as<Name.Parse<'--fooBar', { usedNames: 'foo-bar'; reservedNames: undefined }>>())
-		expectType<Name.Errors.AlreadyTaken<'foo-bar'>>(as<Name.Parse<'--foo-bar', { usedNames: 'fooBar'; reservedNames: undefined }>>())
-		expectType<Name.Errors.AlreadyTaken<'fooBar'>>(as<Name.Parse<'fooBar', { usedNames: 'foo-bar'; reservedNames: undefined }>>())
-		expectType<Name.Errors.AlreadyTaken<'foo-bar'>>(as<Name.Parse<'foo-bar', { usedNames: 'fooBar'; reservedNames: undefined }>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AlreadyTaken<'fooBar'>>>(as<Name.Parse<'--fooBar', { usedNames: 'foo-bar'; reservedNames: undefined }>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AlreadyTaken<'foo-bar'>>>(as<Name.Parse<'--foo-bar', { usedNames: 'fooBar'; reservedNames: undefined }>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AlreadyTaken<'fooBar'>>>(as<Name.Parse<'fooBar', { usedNames: 'foo-bar'; reservedNames: undefined }>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AlreadyTaken<'foo-bar'>>>(as<Name.Parse<'foo-bar', { usedNames: 'fooBar'; reservedNames: undefined }>>())
 			// Aliases
-			expectType<Name.Errors.AlreadyTaken<'fooBar'>>(as<Name.Parse<'--foo --fooBar', { usedNames: 'foo-bar'; reservedNames: undefined }>>())
-			expectType<Name.Errors.AlreadyTaken<'foo-bar'>>(as<Name.Parse<'--foo --foo-bar', { usedNames: 'fooBar'; reservedNames: undefined }>>())
-			expectType<Name.Errors.AlreadyTaken<'fooBar'>>(as<Name.Parse<'foo fooBar', { usedNames: 'foo-bar'; reservedNames: undefined }>>())
-			expectType<Name.Errors.AlreadyTaken<'foo-bar'>>(as<Name.Parse<'foo foo-bar', { usedNames: 'fooBar'; reservedNames: undefined }>>())
+			expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AlreadyTaken<'fooBar'>>>(as<Name.Parse<'--foo --fooBar', { usedNames: 'foo-bar'; reservedNames: undefined }>>())
+			expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AlreadyTaken<'foo-bar'>>>(as<Name.Parse<'--foo --foo-bar', { usedNames: 'fooBar'; reservedNames: undefined }>>())
+			expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AlreadyTaken<'fooBar'>>>(as<Name.Parse<'foo fooBar', { usedNames: 'foo-bar'; reservedNames: undefined }>>())
+			expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AlreadyTaken<'foo-bar'>>>(as<Name.Parse<'foo foo-bar', { usedNames: 'fooBar'; reservedNames: undefined }>>())
 
-	expectType<Name.Errors.LongTooShort<'v'>>(as<			Name.Parse<'--v'>>())
-	expectType<Name.Errors.LongTooShort<'v'>>(as<			Name.Parse<'--ver --v'>>())
-	expectType<Name.Errors.ShortTooLong<'vv'>>(as<		Name.Parse<'-vv'>>())
+	expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.LongTooShort<'v'>>>(as<			Name.Parse<'--v'>>())
+	expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.LongTooShort<'v'>>>(as<			Name.Parse<'--ver --v'>>())
+	expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.ShortTooLong<'vv'>>>(as<		Name.Parse<'-vv'>>())
 
-	expectType<Name.Errors.AliasDuplicate<'vv'>>(as<			Name.Parse<'--vv --vv'>>())
-	expectType<Name.Errors.AliasDuplicate<'v-v'>>(as<			Name.Parse<'--v-v --v-v'>>())
-	expectType<Name.Errors.AliasDuplicate<'v'>>(as<				Name.Parse<'-v -v'>>())
+	expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'vv'>>>(as<			Name.Parse<'--vv --vv'>>())
+	expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'v-v'>>>(as<			Name.Parse<'--v-v --v-v'>>())
+	expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'v'>>>(as<				Name.Parse<'-v -v'>>())
 		// Mixing dash prefix style and kebab/camel case does not matter
-		expectType<Name.Errors.AliasDuplicate<'foo-bar'>>(as<	Name.Parse<'--fooBar --foo-bar'>>())
-		expectType<Name.Errors.AliasDuplicate<'fooBar'>>(as<	Name.Parse<'--foo-bar --fooBar'>>())
-		expectType<Name.Errors.AliasDuplicate<'foo-bar'>>(as<	Name.Parse<'fooBar foo-bar'>>())
-		expectType<Name.Errors.AliasDuplicate<'fooBar'>>(as<	Name.Parse<'foo-bar fooBar'>>())
-		expectType<Name.Errors.AliasDuplicate<'fooBar'>>(as<	Name.Parse<'foo-bar --fooBar'>>())
-		expectType<Name.Errors.AliasDuplicate<'fooBar'>>(as<	Name.Parse<'--foo-bar fooBar'>>())
-		expectType<Name.Errors.AliasDuplicate<'foo-bar'>>(as<	Name.Parse<'fooBar --foo-bar'>>())
-		expectType<Name.Errors.AliasDuplicate<'foo-bar'>>(as<	Name.Parse<'--fooBar foo-bar'>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'foo-bar'>>>(as<	Name.Parse<'--fooBar --foo-bar'>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'fooBar'>>>(as<	Name.Parse<'--foo-bar --fooBar'>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'foo-bar'>>>(as<	Name.Parse<'fooBar foo-bar'>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'fooBar'>>>(as<	Name.Parse<'foo-bar fooBar'>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'fooBar'>>>(as<	Name.Parse<'foo-bar --fooBar'>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'fooBar'>>>(as<	Name.Parse<'--foo-bar fooBar'>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'foo-bar'>>>(as<	Name.Parse<'fooBar --foo-bar'>>())
+		expectType<Name.Checks.Messages.WithHeader<Name.Checks.Messages.AliasDuplicate<'foo-bar'>>>(as<	Name.Parse<'--fooBar foo-bar'>>())
 }
 
 //prettier-ignore


### PR DESCRIPTION
closes #...

#### TASKS

- [ ] Out of band docs (website, README, ...)
- [ ] In of band docs (jsdoc)
- [ ] Tests
